### PR TITLE
RDKB-64136 : XHS/LNF interface entries are missing in zebra.conf 

### DIFF
--- a/source/DHCPMgrUtils/CustomOptions/Makefile.am
+++ b/source/DHCPMgrUtils/CustomOptions/Makefile.am
@@ -30,6 +30,7 @@ libcustomoptions_la_SOURCES = dhcpmgr_custom_options.c
 
 # Include directories
 libcustomoptions_la_CPPFLAGS = -I$(top_srcdir)/source/DHCPServerUtils/utils/include \
-              -I$(top_srcdir)/source/DHCPMgrInterface/include
+              -I$(top_srcdir)/source/DHCPMgrInterface/include \
+              -I$(top_srcdir)/source/DHCPClientUtils/DHCPv4Client/include
 
 

--- a/source/DHCPMgrUtils/CustomOptions/dhcpmgr_custom_options.c
+++ b/source/DHCPMgrUtils/CustomOptions/dhcpmgr_custom_options.c
@@ -90,7 +90,8 @@ __attribute__((weak)) int Get_DhcpV6_CustomOption17(const char *ifName, char *Op
 
 __attribute__((weak)) int add_dhcpv6_option_25(dhcp_opt_list **send_opt_list)
 {
-    char optionValue[] = "\n{ prefix ::/64 }";
+    //TODO : Need to change back to { prefix ::/64 } once sky platform hal fixed
+    char optionValue[] = "\t 0";
 
     if (send_opt_list == NULL)
     {

--- a/source/DHCPMgrUtils/CustomOptions/dhcpmgr_custom_options.c
+++ b/source/DHCPMgrUtils/CustomOptions/dhcpmgr_custom_options.c
@@ -88,6 +88,20 @@ __attribute__((weak)) int Get_DhcpV6_CustomOption17(const char *ifName, char *Op
     return -1;
 }
 
+__attribute__((weak)) int add_dhcpv6_option_25(dhcp_opt_list **send_opt_list)
+{
+    char optionValue[] = "\n{ prefix ::/64 }";
+
+    if (send_opt_list == NULL)
+    {
+        return RETURN_ERR;
+    }
+
+    DHCPMGR_LOG_INFO("%s %d Weak implementation of add_dhcpv6_option_25 \n", __FUNCTION__, __LINE__);
+
+    return add_dhcp_opt_to_list(send_opt_list, DHCPV6_OPT_25, optionValue);
+}
+
 __attribute__((weak)) int Set_DhcpV6_CustomOption17(const char *ifName, const char *OptionValue, uint32_t *ipv6_TimeOffset) 
 {
     DHCPMGR_LOG_INFO("%s %d Weak implementation of Set_DhcpV6_CustomOption17 \n", __FUNCTION__, __LINE__);

--- a/source/DHCPMgrUtils/CustomOptions/dhcpmgr_custom_options.h
+++ b/source/DHCPMgrUtils/CustomOptions/dhcpmgr_custom_options.h
@@ -21,6 +21,7 @@
 #define DHCP_CUSTOM_OPTIONS_H
 #include <stdlib.h>
 #include <stdint.h>
+#include "dhcp_client_common_utils.h"
 /**
  * @brief Creates a custom DHCPv4 Option 43 (Vendor Specific Information) at runtime.
  *
@@ -89,6 +90,17 @@ int Get_DhcpV6_CustomOption16(const char *ifName, char *OptionValue, size_t Opti
  * @return int 0 on success, non-zero on failure.
  */
 int Get_DhcpV6_CustomOption17(const char *ifName, char *OptionValue, size_t OptionValueSize);
+
+/**
+ * @brief Adds DHCPv6 Option 25 (IA_PD) to the send option list.
+ *
+ * This function provides a weak default implementation that can be overridden
+ * by platform code at link time.
+ *
+ * @param[in,out] send_opt_list Pointer to the DHCPv6 send option list.
+ * @return int 0 on success, non-zero on failure.
+ */
+int add_dhcpv6_option_25(dhcp_opt_list **send_opt_list);
 
 /**
  * @brief Sets the custom DHCPv6 Option 17 (Vendor Specific Information Option) value.

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -235,9 +235,13 @@ static int DhcpMgr_build_dhcpv6_opt_list (PCOSA_CONTEXT_DHCPCV6_LINK_OBJECT hIns
 
     if(pDhcp6c->Cfg.RequestPrefixes == TRUE)
     {
-        DHCPMGR_LOG_INFO("%s %d: Adding DHCPv6 option - Number: %d, Value: %s\n", __FUNCTION__, __LINE__, DHCPV6_OPT_25, t1T2Buffer);
         // Identity Association (IA) for Prefix Delegation option OPTION_IA_PD(25) 
-        add_dhcp_opt_to_list(send_opt_list, DHCPV6_OPT_25, t1T2Buffer);
+        DHCPMGR_LOG_INFO("%s %d: Adding DHCPv6 option - Number: %d\n", __FUNCTION__, __LINE__, DHCPV6_OPT_25);
+        if (add_dhcpv6_option_25(send_opt_list) != RETURN_OK)
+        {
+            DHCPMGR_LOG_ERROR("%s %d: Failed to add DHCPv6 option %d.\n", __FUNCTION__, __LINE__, DHCPV6_OPT_25);
+            return RETURN_ERR;
+        }
     }
 
     if(pDhcp6c->Cfg.RapidCommit == TRUE)

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -235,13 +235,9 @@ static int DhcpMgr_build_dhcpv6_opt_list (PCOSA_CONTEXT_DHCPCV6_LINK_OBJECT hIns
 
     if(pDhcp6c->Cfg.RequestPrefixes == TRUE)
     {
+        DHCPMGR_LOG_INFO("%s %d: Adding DHCPv6 option - Number: %d, Value: %s\n", __FUNCTION__, __LINE__, DHCPV6_OPT_25, t1T2Buffer);
         // Identity Association (IA) for Prefix Delegation option OPTION_IA_PD(25) 
-        DHCPMGR_LOG_INFO("%s %d: Adding DHCPv6 option - Number: %d\n", __FUNCTION__, __LINE__, DHCPV6_OPT_25);
-        if (add_dhcpv6_option_25(send_opt_list) != RETURN_OK)
-        {
-            DHCPMGR_LOG_ERROR("%s %d: Failed to add DHCPv6 option %d.\n", __FUNCTION__, __LINE__, DHCPV6_OPT_25);
-            return RETURN_ERR;
-        }
+        add_dhcp_opt_to_list(send_opt_list, DHCPV6_OPT_25, t1T2Buffer);
     }
 
     if(pDhcp6c->Cfg.RapidCommit == TRUE)
@@ -259,7 +255,17 @@ static int DhcpMgr_build_dhcpv6_opt_list (PCOSA_CONTEXT_DHCPCV6_LINK_OBJECT hIns
             pSentOption         = (PCOSA_DML_DHCPCV6_SENT)pCxtLink->hContext;
             if (pSentOption->bEnabled)
             {
-                if(pSentOption->Tag == DHCPV6_OPT_15 && strlen((char *)pSentOption->Value) <= 0)
+                if(pSentOption->Tag == DHCPV6_OPT_25)
+                {
+                    // Identity Association (IA) for Prefix Delegation option OPTION_IA_PD(25)
+                    DHCPMGR_LOG_INFO("%s %d: Adding DHCPv6 option - Number: %d\n", __FUNCTION__, __LINE__, DHCPV6_OPT_25);
+                    if (add_dhcpv6_option_25(send_opt_list) != RETURN_OK)
+                    {
+                        DHCPMGR_LOG_ERROR("%s %d: Failed to add DHCPv6 option %d.\n", __FUNCTION__, __LINE__, DHCPV6_OPT_25);
+                        return RETURN_ERR;
+                    }
+                }
+                else if(pSentOption->Tag == DHCPV6_OPT_15 && strlen((char *)pSentOption->Value) <= 0)
                 {
                     DHCPMGR_LOG_INFO("%s %d: DHCPv6 option 15 (User Class Option) entry found without value. \n", __FUNCTION__, __LINE__);
                     char optionValue[BUFLEN_256] = {0};


### PR DESCRIPTION
RDKB-64136 : XHS/LNF interface entries are missing in zebra.conf 
 Reason for change: Getting the prefix length option from HAL 
 Test Procedure: Check Zebra.conf is having proper config values Risks: Low Signed-off-by:Aadhithan_PE@comcast.com

UT:
https://ccp.sys.comcast.net/browse/RDKB-64136?focusedId=24956655&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-24956655