### PR TITLE
RDKB-64562: MapPSIDLen and MapPSID dmcli parameters return 0

### DIFF
--- a/source/TR-181/middle_layer_src/cosa_dhcpv6_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_dhcpv6_dml.c
@@ -3380,18 +3380,20 @@ dhcp6c_mapt_mape_GetParamUlongValue
     {
         if(MapInfo->MaptAssigned || MapInfo->MapeAssigned)
         {
-            if (MapInfo->MapPSIDLen > 0 && MapInfo->MapEALen == 0)
+            if (MapInfo->MapEALen == 0)
             {
                 *puLong  = MapInfo->MapPSIDLen;
             }
             else
             {
-                /* PSIDLen is calculated from the the Prefix and EALen at WanManager 
+                /* PSIDLen is calculated from the Prefix and EALen at WanManager 
                  * and stored in the device's sysevent db, so we need to get it from there.
                 */
                 char temp[32] = {0};
-                ifl_get_event(SYSEVENT_MAPT_PSID_LENGTH, temp, sizeof(temp));
-                *puLong  = strtoul(temp, NULL, 10);
+                if (ifl_get_event(SYSEVENT_MAPT_PSID_LENGTH, temp, sizeof(temp)) == IFL_SUCCESS)
+                {
+                    *puLong  = strtoul(temp, NULL, 10);
+                }
             }
         }
         return TRUE;
@@ -3401,18 +3403,20 @@ dhcp6c_mapt_mape_GetParamUlongValue
     {
         if(MapInfo->MaptAssigned || MapInfo->MapeAssigned)
         {
-            if (MapInfo->MapPSIDLen > 0 && MapInfo->MapEALen == 0)
+            if (MapInfo->MapEALen == 0)
             {
                 *puLong  = MapInfo->MapPSIDValue;
             }
             else
             {
-                /* PSIDValue value is calculated from the V6 Prefix at WanManager 
+                /* PSIDValue is calculated from the V6 Prefix at WanManager 
                  * and stored in the device's sysevent db, so we need to get it from there.
                 */
                 char temp[32] = {0};
-                ifl_get_event(SYSEVENT_MAPT_PSID_VALUE, temp, sizeof(temp));
-                *puLong  = strtoul(temp, NULL, 10);
+                if (ifl_get_event(SYSEVENT_MAPT_PSID_VALUE, temp, sizeof(temp)) == IFL_SUCCESS)
+                {
+                    *puLong  = strtoul(temp, NULL, 10);
+                }
             }
  
         }

--- a/source/TR-181/middle_layer_src/cosa_dhcpv6_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_dhcpv6_dml.c
@@ -75,6 +75,7 @@
 #include "cosa_drg_common.h"
 #include "cosa_apis_util.h"
 #include "util.h"
+#include "ifl.h"
 
 #include <stdlib.h>
 #include <unistd.h>
@@ -3379,7 +3380,19 @@ dhcp6c_mapt_mape_GetParamUlongValue
     {
         if(MapInfo->MaptAssigned || MapInfo->MapeAssigned)
         {
-           *puLong  = MapInfo->MapPSIDLen;
+            if (MapInfo->MapPSIDLen > 0 && MapInfo->MapEALen == 0)
+            {
+                *puLong  = MapInfo->MapPSIDLen;
+            }
+            else
+            {
+                /* PSIDLen is calculated from the the Prefix and EALen at WanManager 
+                 * and stored in the device's sysevent db, so we need to get it from there.
+                */
+                char temp[32] = {0};
+                ifl_get_event(SYSEVENT_MAPT_PSID_LENGTH, temp, sizeof(temp));
+                *puLong  = strtoul(temp, NULL, 10);
+            }
         }
         return TRUE;
     }
@@ -3388,7 +3401,20 @@ dhcp6c_mapt_mape_GetParamUlongValue
     {
         if(MapInfo->MaptAssigned || MapInfo->MapeAssigned)
         {
-           *puLong  = MapInfo->MapPSIDValue;
+            if (MapInfo->MapPSIDLen > 0 && MapInfo->MapEALen == 0)
+            {
+                *puLong  = MapInfo->MapPSIDValue;
+            }
+            else
+            {
+                /* PSIDValue value is calculated from the V6 Prefix at WanManager 
+                 * and stored in the device's sysevent db, so we need to get it from there.
+                */
+                char temp[32] = {0};
+                ifl_get_event(SYSEVENT_MAPT_PSID_VALUE, temp, sizeof(temp));
+                *puLong  = strtoul(temp, NULL, 10);
+            }
+ 
         }
         return TRUE;
     }


### PR DESCRIPTION
RDKB-64562: MapPSIDLen and MapPSID dmcli parameters return 0 instead of the actual configured values

Reason for change: Fetch the MapPSIDLen and MapPSID from sysevent db when these values are not passed with Option95 (suboption93). Test Procedure:
1. Query Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapPSIDLen and Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption.MapPSID
2. Verify the returned values match the sysevent values "mapt_psid_value" and "mapt_psid_length" Risks: Low
Priority: P1