### PR TITLE
RDKB-64560 : [SKY-VL-QE][Sprint]: IPv4 is Down After MAPT to DS Line Migration.

### DIFF
--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -680,7 +680,7 @@ static void Process_DHCPv6_Handler(char* if_name, dhcp_info_t dml_set_msg)
                 DHCPMGR_LOG_INFO("%s %d: Releasing the IP address and stopping the client\n",__FUNCTION__,__LINE__);
                 release_ip = 1;
 
-		//Reset this flag to avoid unwanted client recovery
+                //Reset this flag to avoid unwanted client recovery
                 pDhcp6c->Cfg.bEnabled = FALSE;
             }
             else if (strcmp(dml_set_msg.ParamName, "Selfheal_ClientRestart") == 0 )

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -510,6 +510,9 @@ static void Process_DHCPv4_Handler(char* if_name, dhcp_info_t dml_set_msg)
             {
                 DHCPMGR_LOG_INFO("%s %d: Releasing the IP address and stopping the client\n",__FUNCTION__,__LINE__);
                 release_ip = 1;
+
+		//Reset this flag to avoid unwanted client recovery
+                pDhcpc->Cfg.bEnabled = FALSE;
             }
             else if (strcmp(dml_set_msg.ParamName, "Selfheal_ClientRestart") == 0 )
             {
@@ -676,6 +679,9 @@ static void Process_DHCPv6_Handler(char* if_name, dhcp_info_t dml_set_msg)
             {
                 DHCPMGR_LOG_INFO("%s %d: Releasing the IP address and stopping the client\n",__FUNCTION__,__LINE__);
                 release_ip = 1;
+
+		//Reset this flag to avoid unwanted client recovery
+                pDhcp6c->Cfg.bEnabled = FALSE;
             }
             else if (strcmp(dml_set_msg.ParamName, "Selfheal_ClientRestart") == 0 )
             {

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -511,7 +511,7 @@ static void Process_DHCPv4_Handler(char* if_name, dhcp_info_t dml_set_msg)
                 DHCPMGR_LOG_INFO("%s %d: Releasing the IP address and stopping the client\n",__FUNCTION__,__LINE__);
                 release_ip = 1;
 
-		//Reset this flag to avoid unwanted client recovery
+                //Reset this flag to avoid unwanted client recovery
                 pDhcpc->Cfg.bEnabled = FALSE;
             }
             else if (strcmp(dml_set_msg.ParamName, "Selfheal_ClientRestart") == 0 )


### PR DESCRIPTION
Reason for change:
sigchld_handler restarts after stopping the client with release. We have to set the Enable to false if the if the client stopped using X_RDK_Release.

Test Procedure:
1. Client should not restart after DHCP client stop until WanManager says.
2. DHCPManager should be working as expected

Risks: Medium