### PR TITLE
RDKB-64560: IPv4 goes down after MAP-T to DS Line migration

### DIFF
--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -589,6 +589,8 @@ static void Process_DHCPv4_Handler(char* if_name, dhcp_info_t dml_set_msg)
                 if(release_ip)
                 {
                     send_dhcpv4_release(pDhcpc->Info.ClientProcessId);
+                    /* X_RDK_Release: disable the client */
+                    pDhcpc->Cfg.bEnabled = FALSE;
                 }
                 else
                 {
@@ -760,6 +762,8 @@ static void Process_DHCPv6_Handler(char* if_name, dhcp_info_t dml_set_msg)
                 if(release_ip)
                 {
                     send_dhcpv6_release(pDhcp6c->Info.ClientProcessId);
+                    /* X_RDK_Release: disable the client */
+                    pDhcp6c->Cfg.bEnabled = FALSE;
                 }
                 else
                 {


### PR DESCRIPTION
During MAP‑T to DS Line migration, the X_RDK_Release flag triggers the release of WAN-related IP configurations. However, the DHCPv4 client was not being stopped or disabled as part of this flow. As a result, the device ended up in a state where IPv4 was not reacquired, leaving the WAN interface without an IPv4 address.
This change introduces the following fixes:

Properly stop/disable the DHCP client when X_RDK_Release is triggered.
Ensure that any active DHCPv4 lease is released and cleaned up.
Prevent leftover DHCP processes from interfering with re‑initialization after the migration.
Restore consistent IPv4 connectivity after MAP-T to DS Line migration.

This ensures stable IPv4 behavior across MAP‑T transitions and prevents the IPv4 down condition observed in RDKB‑64560.

UT:https://ccp.sys.comcast.net/browse/RDKB-64560?focusedId=25146721&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-25146721

https://ccp.sys.comcast.net/browse/RDKB-64560?focusedId=25147864&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-25147864