### PR TITLE
RDKB-21853: Fix DHCPManager hang - replace popen/pclose with /proc/net/if_inet6 in DhcpMgr_checkLinkLocalAddress

### DIFF
--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -427,13 +427,14 @@ static bool DhcpMgr_checkInterfaceStatus(const char * ifName)
 /**
  * @brief Checks for the presence of a link-local address and its DAD status on a network interface.
  *
- * This function checks if the specified network interface has a link-local address (LLA) by
- * executing the command `ip address show dev %s tentative`. It also verifies the link-local
- * Duplicate Address Detection (DAD) status. If no LLA is found, it restarts the IPv6 stack
- * on the interface.
+ * This function reads /proc/net/if_inet6 to check whether the specified interface
+ * has a link-local address (scope 0x20) that has completed Duplicate Address
+ * Detection (DAD). It waits up to INTF_V6LL_TIMEOUT_IN_MSEC for DAD to finish.
+ * If no link-local address is found within the timeout, it restarts the IPv6
+ * stack on the interface.
  *
  * @param interfaceName The name of the network interface to check.
- * @return true if the link-local address is found and DAD status is verified, false otherwise.
+ * @return true if the link-local address is found and DAD is complete, false otherwise.
  */
 static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
 { 
@@ -460,6 +461,12 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
                 if (strcmp(ifname, interfaceName) != 0)
                     continue;   /* skip entries for other interfaces */
 
+                /* Only consider link-local addresses (scope 0x20 = IPV6_ADDR_LINKLOCAL).
+                 * Global/site-local addresses present without a link-local do not
+                 * satisfy the readiness check this function is designed to verify. */
+                if (scope != 0x20U)
+                    continue;
+
                 iface_found = true;
                 if (flags & IFA_F_TENTATIVE)
                 {
@@ -471,9 +478,12 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
         }
         else
         {
-            /* Cannot determine DAD state; log and assume ready to avoid stalling */
-            DHCPMGR_LOG_WARNING("%s %d: failed to open /proc/net/if_inet6 (%s), skipping tentative check\n",
+            /* Cannot open /proc/net/if_inet6 — kernel file unavailable.
+             * DAD state is indeterminate; break out and let DHCPv6 proceed
+             * rather than stalling until timeout. */
+            DHCPMGR_LOG_ERROR("%s %d: failed to open /proc/net/if_inet6 (%s), skipping DAD check\n",
                                 __FUNCTION__, __LINE__, strerror(errno));
+            break;
         }
 
         /* If interface has no IPv6 address yet, keep waiting */

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -50,6 +50,7 @@
 #include "dhcpmgr_custom_options.h"
 #include "cosa_apis_util.h"
 #include <telemetry_busmessage_sender.h>
+#include <linux/if_addr.h>     /* IFA_F_TENTATIVE */
 
 
 /* ---- Global Constants -------------------------- */
@@ -437,24 +438,36 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
 { 
     // check if interface is ipv6 ready with a link-local address
     unsigned int waitTime = INTF_V6LL_TIMEOUT_IN_MSEC;
-    char cmd[BUFLEN_128] = {0};
-    snprintf(cmd, sizeof(cmd), "ip address show dev %s tentative", interfaceName);
+
     while (waitTime > 0)
     {
-        FILE *fp_dad   = NULL;
-        char buffer[BUFLEN_256] = {0};
-
-        fp_dad = popen(cmd, "r");
-        if(fp_dad != NULL)
+        /* Read /proc/net/if_inet6 directly instead of popen("ip address show tentative").
+         * popen() spawns a child process which races with the global SIGCHLD handler
+         * (waitpid(-1,...)) causing pclose() to hang when the handler reaps the child first.
+         * /proc/net/if_inet6 format: addr32hex if_idx prefix_len scope flags ifname
+         * IFA_F_TENTATIVE (0x40) set while the address is undergoing DAD. */
+        bool tentative = false;
+        FILE *fp_inet6 = fopen("/proc/net/if_inet6", "r");
+        if (fp_inet6 != NULL)
         {
-            if ((fgets(buffer, BUFLEN_256, fp_dad) == NULL) || (strlen(buffer) == 0))
+            char addr[33];
+            int if_idx, pfx_len, scope, flags;
+            char ifname[IF_NAMESIZE + 1];
+            while (fscanf(fp_inet6, "%32s %x %x %x %x %16s", addr, &if_idx, &pfx_len, &scope, &flags, ifname) == 6)
             {
-                pclose(fp_dad);
-                break;
+                if ((strcmp(ifname, interfaceName) == 0) && (flags & IFA_F_TENTATIVE))
+                {
+                    tentative = true;
+                    break;
+                }
             }
-            DHCPMGR_LOG_WARNING("%s %d: interface still tentative: %s\n", __FUNCTION__, __LINE__, buffer);
-            pclose(fp_dad);
+            fclose(fp_inet6);
         }
+
+        if (!tentative)
+            break;
+
+        DHCPMGR_LOG_WARNING("%s %d: interface still tentative: %s\n", __FUNCTION__, __LINE__, interfaceName);
         usleep(INTF_V6LL_INTERVAL_IN_MSEC * USECS_IN_MSEC);
         waitTime -= INTF_V6LL_INTERVAL_IN_MSEC;
     }

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -434,7 +434,10 @@ static bool DhcpMgr_checkInterfaceStatus(const char * ifName)
  * stack on the interface.
  *
  * @param interfaceName The name of the network interface to check.
- * @return true if the link-local address is found and DAD is complete, false otherwise.
+ * @return true if at least one link-local address exists and none are tentative
+ *         (DAD complete), or if /proc/net/if_inet6 cannot be opened (DAD check
+ *         skipped — callers should not assume DAD was verified in that case).
+ *         Returns false if no link-local address appears within the timeout.
  */
 static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
 { 
@@ -471,6 +474,14 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
                 if (flags & IFA_F_TENTATIVE)
                 {
                     tentative = true;
+                    /* Do NOT break here: there may be multiple link-local
+                     * entries; a later one may already be non-tentative. */
+                }
+                else
+                {
+                    /* At least one link-local address is ready — DAD complete.
+                     * No need to scan further. */
+                    tentative = false;
                     break;
                 }
             }
@@ -486,10 +497,10 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
             break;
         }
 
-        /* If interface has no IPv6 address yet, keep waiting */
+        /* If no link-local address found yet, keep waiting */
         if (!iface_found)
         {
-            DHCPMGR_LOG_WARNING("%s %d: interface %s not found in /proc/net/if_inet6, waiting...\n",
+            DHCPMGR_LOG_WARNING("%s %d: no link-local address for %s in /proc/net/if_inet6 yet, waiting...\n",
                                 __FUNCTION__, __LINE__, interfaceName);
         }
         else if (!tentative)

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -448,6 +448,7 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
          * /proc/net/if_inet6 format: addr32hex if_idx prefix_len scope flags ifname
          * IFA_F_TENTATIVE (0x40) set while the address is undergoing DAD. */
         bool tentative = false;
+        bool iface_found = false;
         FILE *fp_inet6 = fopen("/proc/net/if_inet6", "r");
         if (fp_inet6 != NULL)
         {
@@ -456,7 +457,11 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
             char ifname[IF_NAMESIZE + 1];
             while (fscanf(fp_inet6, "%32s %x %x %x %x %16s", addr, &if_idx, &pfx_len, &scope, &flags, ifname) == 6)
             {
-                if ((strcmp(ifname, interfaceName) == 0) && (flags & IFA_F_TENTATIVE))
+                if (strcmp(ifname, interfaceName) != 0)
+                    continue;   /* skip entries for other interfaces */
+
+                iface_found = true;
+                if (flags & IFA_F_TENTATIVE)
                 {
                     tentative = true;
                     break;
@@ -471,8 +476,14 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
                                 __FUNCTION__, __LINE__, strerror(errno));
         }
 
-        if (!tentative)
-            break;
+        /* If interface has no IPv6 address yet, keep waiting */
+        if (!iface_found)
+        {
+            DHCPMGR_LOG_WARNING("%s %d: interface %s not found in /proc/net/if_inet6, waiting...\n",
+                                __FUNCTION__, __LINE__, interfaceName);
+        }
+        else if (!tentative)
+            break;  /* interface found and no tentative address — DAD complete */
 
         DHCPMGR_LOG_WARNING("%s %d: interface still tentative: %s\n", __FUNCTION__, __LINE__, interfaceName);
         usleep(INTF_V6LL_INTERVAL_IN_MSEC * USECS_IN_MSEC);

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -483,9 +483,13 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
                                 __FUNCTION__, __LINE__, interfaceName);
         }
         else if (!tentative)
+        {
             break;  /* interface found and no tentative address — DAD complete */
-
-        DHCPMGR_LOG_WARNING("%s %d: interface still tentative: %s\n", __FUNCTION__, __LINE__, interfaceName);
+        }
+        else
+        {
+            DHCPMGR_LOG_WARNING("%s %d: interface still tentative: %s\n", __FUNCTION__, __LINE__, interfaceName);
+        }
         usleep(INTF_V6LL_INTERVAL_IN_MSEC * USECS_IN_MSEC);
         waitTime -= INTF_V6LL_INTERVAL_IN_MSEC;
     }

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/socket.h>
@@ -451,7 +452,7 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
         if (fp_inet6 != NULL)
         {
             char addr[33];
-            int if_idx, pfx_len, scope, flags;
+            unsigned int if_idx, pfx_len, scope, flags;
             char ifname[IF_NAMESIZE + 1];
             while (fscanf(fp_inet6, "%32s %x %x %x %x %16s", addr, &if_idx, &pfx_len, &scope, &flags, ifname) == 6)
             {
@@ -462,6 +463,12 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
                 }
             }
             fclose(fp_inet6);
+        }
+        else
+        {
+            /* Cannot determine DAD state; log and assume ready to avoid stalling */
+            DHCPMGR_LOG_WARNING("%s %d: failed to open /proc/net/if_inet6 (%s), skipping tentative check\n",
+                                __FUNCTION__, __LINE__, strerror(errno));
         }
 
         if (!tentative)

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -434,9 +434,10 @@ static bool DhcpMgr_checkInterfaceStatus(const char * ifName)
  * stack on the interface.
  *
  * @param interfaceName The name of the network interface to check.
- * @return true if at least one link-local address exists and none are tentative
- *         (DAD complete), or if /proc/net/if_inet6 cannot be opened (DAD check
- *         skipped — callers should not assume DAD was verified in that case).
+ * @return true if at least one link-local address is found and ready (DAD
+ *         complete for that address — scan stops at the first non-tentative LLA),
+ *         or if /proc/net/if_inet6 cannot be opened (DAD check skipped —
+ *         callers should not assume DAD was verified in that case).
  *         Returns false if no link-local address appears within the timeout.
  */
 static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
@@ -505,7 +506,7 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
         }
         else if (!tentative)
         {
-            break;  /* interface found and no tentative address — DAD complete */
+            break;  /* at least one link-local address is ready (DAD complete) */
         }
         else
         {


### PR DESCRIPTION
## Problem
DHCPManager intermittently hangs during IPv6 client startup in `DhcpMgr_checkLinkLocalAddress`, making the process unresponsive.

## Root Cause
`popen("ip address show dev <iface> tentative")` spawns a shell child process. The global `sigchld_handler` uses `waitpid(-1, WNOHANG)` which reaps **all** child processes. When it reaps the popen child before `pclose()` runs, `pclose()` blocks forever — hanging the DHCPManager thread.

## Fix
Replace `popen`/`pclose` with a direct read of `/proc/net/if_inet6`:
- No child process spawned, no SIGCHLD interference
- Format: `addr32hex if_idx prefix_len scope flags ifname`
- `IFA_F_TENTATIVE (0x40)` in flags indicates address is undergoing DAD
- Uses only `fopen`/`fscanf`/`fclose` — safe in all contexts

## Files Changed
- `source/DHCPMgrUtils/dhcpmgr_controller.c`
  - Added `#include <linux/if_addr.h>` for `IFA_F_TENTATIVE`
  - Replaced `popen/fgets/pclose` loop with `fopen/fscanf/fclose` on `/proc/net/if_inet6`

## Test Procedure
1. Flash build on device
2. Trigger WAN down/up cycle 10+ times
3. Verify DHCPManager does NOT hang after IPv6 client restart
4. Check DHCPMGRLog.txt: `interface still tentative` appears during DAD, DHCPv6 starts successfully after
5. Run factory reset and verify WAN recovers
6. Confirm no DHCPv4/DHCPv6 lease regression

## Verification
Fix verified on XB8 — DHCPManager no longer hangs after multiple WAN down/up cycles.