### PR TITLE
SHARMAN-4100: Fix DHCPManager hang - replace popen/pclose with /proc/net/if_inet6 in DhcpMgr_checkLinkLocalAddress

### DIFF
--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -425,8 +425,6 @@ static bool DhcpMgr_checkInterfaceStatus(const char * ifName)
 }
 
 /**
- * @brief Checks for the presence of a link-local address and its DAD status on a network interface.
-/**
  * @brief Checks if the link-local address on a network interface has completed DAD.
  *
  * Reads /proc/net/if_inet6 to find a link-local address (scope 0x20) on the

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -880,6 +880,7 @@ void* DhcpMgr_MainController( void *args )
     mq_send_msg_t mq_msg_info;
     char inf_name[MAX_STR_LEN] = {0};
     char mq_name[MQ_NAME_LEN] = {0};
+    bool mutex_locked = false;
     
     memset(&mq_msg_info, 0, sizeof(mq_send_msg_t));
     if(args != NULL)
@@ -953,6 +954,11 @@ void* DhcpMgr_MainController( void *args )
                     if(DhcpMgr_LockInterfaceQueueMutexByName(inf_name) != 0) // lock the mutex
                     {
                         DHCPMGR_LOG_ERROR("%s %d Failed to lock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
+                        mutex_locked = false;
+                    }
+                    else
+                    {
+                        mutex_locked = true;
                     }
                     break; // exit thread after timeout
                 }
@@ -966,6 +972,11 @@ void* DhcpMgr_MainController( void *args )
                 if(DhcpMgr_LockInterfaceQueueMutexByName(inf_name) != 0) // lock the mutex on error
                 {
                     DHCPMGR_LOG_ERROR("%s %d Failed to lock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
+                    mutex_locked = false;
+                }
+                else
+                {
+                    mutex_locked = true;
                 }
                 break;
             }
@@ -977,9 +988,12 @@ void* DhcpMgr_MainController( void *args )
     mark_thread_stopped(inf_name);
     mq_close(mq_desc);
 
-    if(DhcpMgr_UnlockInterfaceQueueMutexByName(inf_name) != 0) //MUTEX unlock
+    if(mutex_locked)
     {
-        DHCPMGR_LOG_ERROR("%s %d Failed to unlock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
+        if(DhcpMgr_UnlockInterfaceQueueMutexByName(inf_name) != 0) //MUTEX unlock
+        {
+            DHCPMGR_LOG_ERROR("%s %d Failed to unlock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
+        }
     }
     
     /* Mark thread as stopped so new one can be created if needed */

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -969,8 +969,8 @@ void* DhcpMgr_MainController( void *args )
     /*
      * Hold q_mutex around mark_thread_stopped + mq_close so that a concurrent
      * DhcpMgr_OpenQueueEnsureThread cannot deliver a message to a queue that is
-     * already being closed. q_mutex is acquired here alone; global_mutex is not
-     * held across this section.
+     * already being closed. Note: mark_thread_stopped() acquires global_mutex
+     * internally, so the effective lock order here is q_mutex -> global_mutex.
      */
     if (DhcpMgr_LockInterfaceQueueMutexByName(inf_name) == 0)
     {

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -880,7 +880,6 @@ void* DhcpMgr_MainController( void *args )
     mq_send_msg_t mq_msg_info;
     char inf_name[MAX_STR_LEN] = {0};
     char mq_name[MQ_NAME_LEN] = {0};
-    bool mutex_locked = false;
     
     memset(&mq_msg_info, 0, sizeof(mq_send_msg_t));
     if(args != NULL)
@@ -954,11 +953,6 @@ void* DhcpMgr_MainController( void *args )
                     if(DhcpMgr_LockInterfaceQueueMutexByName(inf_name) != 0) // lock the mutex
                     {
                         DHCPMGR_LOG_ERROR("%s %d Failed to lock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
-                        mutex_locked = false;
-                    }
-                    else
-                    {
-                        mutex_locked = true;
                     }
                     break; // exit thread after timeout
                 }
@@ -972,11 +966,6 @@ void* DhcpMgr_MainController( void *args )
                 if(DhcpMgr_LockInterfaceQueueMutexByName(inf_name) != 0) // lock the mutex on error
                 {
                     DHCPMGR_LOG_ERROR("%s %d Failed to lock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
-                    mutex_locked = false;
-                }
-                else
-                {
-                    mutex_locked = true;
                 }
                 break;
             }
@@ -988,12 +977,9 @@ void* DhcpMgr_MainController( void *args )
     mark_thread_stopped(inf_name);
     mq_close(mq_desc);
 
-    if(mutex_locked)
+    if(DhcpMgr_UnlockInterfaceQueueMutexByName(inf_name) != 0) //MUTEX unlock
     {
-        if(DhcpMgr_UnlockInterfaceQueueMutexByName(inf_name) != 0) //MUTEX unlock
-        {
-            DHCPMGR_LOG_ERROR("%s %d Failed to unlock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
-        }
+        DHCPMGR_LOG_ERROR("%s %d Failed to unlock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
     }
     
     /* Mark thread as stopped so new one can be created if needed */

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/socket.h>
@@ -52,6 +51,7 @@
 #include "cosa_apis_util.h"
 #include <telemetry_busmessage_sender.h>
 #include <linux/if_addr.h>     /* IFA_F_TENTATIVE */
+#include <string.h>            /* strerror */
 
 
 /* ---- Global Constants -------------------------- */
@@ -424,6 +424,8 @@ static bool DhcpMgr_checkInterfaceStatus(const char * ifName)
     return TRUE;
 }
 
+/**
+ * @brief Checks for the presence of a link-local address and its DAD status on a network interface.
 /**
  * @brief Checks if the link-local address on a network interface has completed DAD.
  *
@@ -950,6 +952,10 @@ void* DhcpMgr_MainController( void *args )
                 if (retry_count >= max_retries)
                 {
                     DHCPMGR_LOG_DEBUG("%s %d: mq_receive timeout after 5s on %s\n",__FUNCTION__, __LINE__, mq_name);
+                    if(DhcpMgr_LockInterfaceQueueMutexByName(inf_name) != 0) // lock the mutex
+                    {
+                        DHCPMGR_LOG_ERROR("%s %d Failed to lock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
+                    }
                     break; // exit thread after timeout
                 }
 
@@ -959,6 +965,10 @@ void* DhcpMgr_MainController( void *args )
             {
                 /* Real error, exit thread */
                 DHCPMGR_LOG_ERROR("%s %d: mq_receive failed errno=%d (%s)\n",__FUNCTION__, __LINE__, errno, strerror(errno));
+                if(DhcpMgr_LockInterfaceQueueMutexByName(inf_name) != 0) // lock the mutex on error
+                {
+                    DHCPMGR_LOG_ERROR("%s %d Failed to lock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
+                }
                 break;
             }
         }
@@ -966,29 +976,15 @@ void* DhcpMgr_MainController( void *args )
 
 
     DHCPMGR_LOG_DEBUG("%s %d: Cleaning up DhcpMgr_MainController thread for interface %s\n", __FUNCTION__, __LINE__, inf_name);
-    /*
-     * Hold q_mutex around mark_thread_stopped + mq_close so that a concurrent
-     * DhcpMgr_OpenQueueEnsureThread cannot deliver a message to a queue that is
-     * already being closed. Note: mark_thread_stopped() acquires global_mutex
-     * internally, so the effective lock order here is q_mutex -> global_mutex.
-     */
-    if (DhcpMgr_LockInterfaceQueueMutexByName(inf_name) == 0)
+    mark_thread_stopped(inf_name);
+    mq_close(mq_desc);
+
+    if(DhcpMgr_UnlockInterfaceQueueMutexByName(inf_name) != 0) //MUTEX unlock
     {
-        mark_thread_stopped(inf_name);
-        mq_close(mq_desc);
-        if (DhcpMgr_UnlockInterfaceQueueMutexByName(inf_name) != 0)
-        {
-            DHCPMGR_LOG_ERROR("%s %d: Failed to unlock queue mutex for %s\n",
-                              __FUNCTION__, __LINE__, inf_name);
-        }
+        DHCPMGR_LOG_ERROR("%s %d Failed to unlock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
     }
-    else
-    {
-        DHCPMGR_LOG_ERROR("%s %d: Failed to acquire queue mutex for %s, attempting cleanup anyway\n",
-                          __FUNCTION__, __LINE__, inf_name);
-        mark_thread_stopped(inf_name);
-        mq_close(mq_desc);
-    }
+    
+    /* Mark thread as stopped so new one can be created if needed */
     DHCPMGR_LOG_DEBUG("%s %d: Exiting DhcpMgr_MainController thread for mq %s\n", __FUNCTION__, __LINE__, mq_name);
     return NULL;
 

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -457,10 +457,13 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
         FILE *fp_inet6 = fopen("/proc/net/if_inet6", "r");
         if (fp_inet6 != NULL)
         {
-            unsigned int scope, flags;
+            char addr[33];
+            unsigned int if_idx, pfx_len, scope, flags;
             char ifname[IF_NAMESIZE + 1];
-            /* Suppress addr/if_idx/pfx_len with %* to avoid -Wunused-but-set-variable */
-            while (fscanf(fp_inet6, "%*s %*x %*x %x %x %16s", &scope, &flags, ifname) == 3)
+            while (fscanf(fp_inet6, "%32s %x %x %x %x %16s",
+                          addr, &if_idx, &pfx_len, &scope, &flags, ifname) == 6)
+            {
+                (void)addr; (void)if_idx; (void)pfx_len; /* only scope/flags/ifname used */
             {
                 if (strcmp(ifname, interfaceName) != 0)
                     continue;   /* skip entries for other interfaces */

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/socket.h>
@@ -50,6 +51,7 @@
 #include "dhcpmgr_custom_options.h"
 #include "cosa_apis_util.h"
 #include <telemetry_busmessage_sender.h>
+#include <linux/if_addr.h>     /* IFA_F_TENTATIVE */
 
 
 /* ---- Global Constants -------------------------- */
@@ -425,35 +427,90 @@ static bool DhcpMgr_checkInterfaceStatus(const char * ifName)
 /**
  * @brief Checks for the presence of a link-local address and its DAD status on a network interface.
  *
- * This function checks if the specified network interface has a link-local address (LLA) by
- * executing the command `ip address show dev %s tentative`. It also verifies the link-local
- * Duplicate Address Detection (DAD) status. If no LLA is found, it restarts the IPv6 stack
- * on the interface.
+ * This function reads /proc/net/if_inet6 to check whether the specified interface
+ * has a link-local address (scope 0x20) that has completed Duplicate Address
+ * Detection (DAD). It waits up to INTF_V6LL_TIMEOUT_IN_MSEC for DAD to finish.
+ * If no link-local address is found within the timeout, it restarts the IPv6
+ * stack on the interface.
  *
  * @param interfaceName The name of the network interface to check.
- * @return true if the link-local address is found and DAD status is verified, false otherwise.
+ * @return true if at least one link-local address is found and ready (DAD
+ *         complete for that address — scan stops at the first non-tentative LLA),
+ *         or if /proc/net/if_inet6 cannot be opened (DAD check skipped —
+ *         callers should not assume DAD was verified in that case).
+ *         Returns false if no link-local address appears within the timeout.
  */
 static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
 { 
     // check if interface is ipv6 ready with a link-local address
     unsigned int waitTime = INTF_V6LL_TIMEOUT_IN_MSEC;
-    char cmd[BUFLEN_128] = {0};
-    snprintf(cmd, sizeof(cmd), "ip address show dev %s tentative", interfaceName);
+
     while (waitTime > 0)
     {
-        FILE *fp_dad   = NULL;
-        char buffer[BUFLEN_256] = {0};
-
-        fp_dad = popen(cmd, "r");
-        if(fp_dad != NULL)
+        /* Read /proc/net/if_inet6 directly instead of popen("ip address show tentative").
+         * popen() spawns a child process which races with the global SIGCHLD handler
+         * (waitpid(-1,...)) causing pclose() to hang when the handler reaps the child first.
+         * /proc/net/if_inet6 format: addr32hex if_idx prefix_len scope flags ifname
+         * IFA_F_TENTATIVE (0x40) set while the address is undergoing DAD. */
+        bool tentative = false;
+        bool iface_found = false;
+        FILE *fp_inet6 = fopen("/proc/net/if_inet6", "r");
+        if (fp_inet6 != NULL)
         {
-            if ((fgets(buffer, BUFLEN_256, fp_dad) == NULL) || (strlen(buffer) == 0))
+            char addr[33];
+            unsigned int if_idx, pfx_len, scope, flags;
+            char ifname[IF_NAMESIZE + 1];
+            while (fscanf(fp_inet6, "%32s %x %x %x %x %16s", addr, &if_idx, &pfx_len, &scope, &flags, ifname) == 6)
             {
-                pclose(fp_dad);
-                break;
+                if (strcmp(ifname, interfaceName) != 0)
+                    continue;   /* skip entries for other interfaces */
+
+                /* Only consider link-local addresses (scope 0x20 = IPV6_ADDR_LINKLOCAL).
+                 * Global/site-local addresses present without a link-local do not
+                 * satisfy the readiness check this function is designed to verify. */
+                if (scope != 0x20U)
+                    continue;
+
+                iface_found = true;
+                if (flags & IFA_F_TENTATIVE)
+                {
+                    tentative = true;
+                    /* Do NOT break here: there may be multiple link-local
+                     * entries; a later one may already be non-tentative. */
+                }
+                else
+                {
+                    /* At least one link-local address is ready — DAD complete.
+                     * No need to scan further. */
+                    tentative = false;
+                    break;
+                }
             }
-            DHCPMGR_LOG_WARNING("%s %d: interface still tentative: %s\n", __FUNCTION__, __LINE__, buffer);
-            pclose(fp_dad);
+            fclose(fp_inet6);
+        }
+        else
+        {
+            /* Cannot open /proc/net/if_inet6 — kernel file unavailable.
+             * DAD state is indeterminate; break out and let DHCPv6 proceed
+             * rather than stalling until timeout. */
+            DHCPMGR_LOG_ERROR("%s %d: failed to open /proc/net/if_inet6 (%s), skipping DAD check\n",
+                                __FUNCTION__, __LINE__, strerror(errno));
+            break;
+        }
+
+        /* If no link-local address found yet, keep waiting */
+        if (!iface_found)
+        {
+            DHCPMGR_LOG_WARNING("%s %d: no link-local address for %s in /proc/net/if_inet6 yet, waiting...\n",
+                                __FUNCTION__, __LINE__, interfaceName);
+        }
+        else if (!tentative)
+        {
+            break;  /* at least one link-local address is ready (DAD complete) */
+        }
+        else
+        {
+            DHCPMGR_LOG_WARNING("%s %d: interface still tentative: %s\n", __FUNCTION__, __LINE__, interfaceName);
         }
         usleep(INTF_V6LL_INTERVAL_IN_MSEC * USECS_IN_MSEC);
         waitTime -= INTF_V6LL_INTERVAL_IN_MSEC;
@@ -905,10 +962,6 @@ void* DhcpMgr_MainController( void *args )
                 if (retry_count >= max_retries)
                 {
                     DHCPMGR_LOG_DEBUG("%s %d: mq_receive timeout after 5s on %s\n",__FUNCTION__, __LINE__, mq_name);
-                    if(DhcpMgr_LockInterfaceQueueMutexByName(inf_name) != 0) // lock the mutex
-                    {
-                        DHCPMGR_LOG_ERROR("%s %d Failed to lock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
-                    }
                     break; // exit thread after timeout
                 }
 
@@ -918,10 +971,6 @@ void* DhcpMgr_MainController( void *args )
             {
                 /* Real error, exit thread */
                 DHCPMGR_LOG_ERROR("%s %d: mq_receive failed errno=%d (%s)\n",__FUNCTION__, __LINE__, errno, strerror(errno));
-                if(DhcpMgr_LockInterfaceQueueMutexByName(inf_name) != 0) // lock the mutex on error
-                {
-                    DHCPMGR_LOG_ERROR("%s %d Failed to lock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
-                }
                 break;
             }
         }
@@ -929,15 +978,16 @@ void* DhcpMgr_MainController( void *args )
 
 
     DHCPMGR_LOG_DEBUG("%s %d: Cleaning up DhcpMgr_MainController thread for interface %s\n", __FUNCTION__, __LINE__, inf_name);
+    /*
+     * Hold q_mutex around mark_thread_stopped + mq_close so that
+     * DhcpMgr_OpenQueueEnsureThread (which also holds q_mutex while sending)
+     * cannot deliver a message to a queue that is already closed.
+     * Lock order: q_mutex -> global_mutex (same as in OpenQueueEnsureThread).
+     */
+    DhcpMgr_LockInterfaceQueueMutexByName(inf_name);
     mark_thread_stopped(inf_name);
     mq_close(mq_desc);
-
-    if(DhcpMgr_UnlockInterfaceQueueMutexByName(inf_name) != 0) //MUTEX unlock
-    {
-        DHCPMGR_LOG_ERROR("%s %d Failed to unlock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
-    }
-    
-    /* Mark thread as stopped so new one can be created if needed */
+    DhcpMgr_UnlockInterfaceQueueMutexByName(inf_name);
     DHCPMGR_LOG_DEBUG("%s %d: Exiting DhcpMgr_MainController thread for mq %s\n", __FUNCTION__, __LINE__, mq_name);
     return NULL;
 

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -425,52 +425,42 @@ static bool DhcpMgr_checkInterfaceStatus(const char * ifName)
 }
 
 /**
- * @brief Checks for the presence of a link-local address and its DAD status on a network interface.
+ * @brief Checks if the link-local address on a network interface has completed DAD.
  *
- * This function reads /proc/net/if_inet6 to check whether the specified interface
- * has a link-local address (scope 0x20) that has completed Duplicate Address
- * Detection (DAD). It waits up to INTF_V6LL_TIMEOUT_IN_MSEC for DAD to finish.
- * If no link-local address is found within the timeout, it restarts the IPv6
- * stack on the interface.
+ * Reads /proc/net/if_inet6 to find a link-local address (scope 0x20) on the
+ * given interface. Waits up to INTF_V6LL_TIMEOUT_IN_MSEC for DAD to finish.
+ * If no link-local address appears within the timeout, restarts the IPv6 stack.
  *
- * @param interfaceName The name of the network interface to check.
- * @return true if at least one link-local address is found and ready (DAD
- *         complete for that address — scan stops at the first non-tentative LLA),
- *         or if /proc/net/if_inet6 cannot be opened (DAD check skipped —
- *         callers should not assume DAD was verified in that case).
+ * @param interfaceName The network interface to check.
+ * @return true when at least one non-tentative link-local address is found,
+ *         or when /proc/net/if_inet6 cannot be opened (DAD check skipped).
  *         Returns false if no link-local address appears within the timeout.
  */
 static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
-{ 
-    // check if interface is ipv6 ready with a link-local address
+{
     unsigned int waitTime = INTF_V6LL_TIMEOUT_IN_MSEC;
 
     while (waitTime > 0)
     {
-        /* Read /proc/net/if_inet6 directly instead of popen("ip address show tentative").
-         * popen() spawns a child process which races with the global SIGCHLD handler
-         * (waitpid(-1,...)) causing pclose() to hang when the handler reaps the child first.
-         * /proc/net/if_inet6 format: addr32hex if_idx prefix_len scope flags ifname
-         * IFA_F_TENTATIVE (0x40) set while the address is undergoing DAD. */
         bool tentative = false;
         bool iface_found = false;
+
         FILE *fp_inet6 = fopen("/proc/net/if_inet6", "r");
         if (fp_inet6 != NULL)
         {
             char addr[33];
             unsigned int if_idx, pfx_len, scope, flags;
             char ifname[IF_NAMESIZE + 1];
+
             while (fscanf(fp_inet6, "%32s %x %x %x %x %16s",
                           addr, &if_idx, &pfx_len, &scope, &flags, ifname) == 6)
             {
-                (void)addr; (void)if_idx; (void)pfx_len; /* only scope/flags/ifname used */
-            {
-                if (strcmp(ifname, interfaceName) != 0)
-                    continue;   /* skip entries for other interfaces */
+                (void)addr; (void)if_idx; (void)pfx_len;
 
-                /* Only consider link-local addresses (scope 0x20 = IPV6_ADDR_LINKLOCAL).
-                 * Global/site-local addresses present without a link-local do not
-                 * satisfy the readiness check this function is designed to verify. */
+                if (strcmp(ifname, interfaceName) != 0)
+                    continue;
+
+                /* Only check link-local addresses (scope 0x20 = IPV6_ADDR_LINKLOCAL) */
                 if (scope != 0x20U)
                     continue;
 
@@ -478,43 +468,38 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
                 if (flags & IFA_F_TENTATIVE)
                 {
                     tentative = true;
-                    /* Do NOT break here: there may be multiple link-local
-                     * entries; a later one may already be non-tentative. */
+                    /* keep scanning — a later entry may already be non-tentative */
                 }
                 else
                 {
-                    /* At least one link-local address is ready — DAD complete.
-                     * No need to scan further. */
                     tentative = false;
-                    break;
+                    break; /* at least one link-local address is ready */
                 }
             }
             fclose(fp_inet6);
         }
         else
         {
-            /* Cannot open /proc/net/if_inet6 — kernel file unavailable.
-             * DAD state is indeterminate; break out and let DHCPv6 proceed
-             * rather than stalling until timeout. */
             DHCPMGR_LOG_ERROR("%s %d: failed to open /proc/net/if_inet6 (%s), skipping DAD check\n",
-                                __FUNCTION__, __LINE__, strerror(errno));
+                              __FUNCTION__, __LINE__, strerror(errno));
             break;
         }
 
-        /* If no link-local address found yet, keep waiting */
         if (!iface_found)
         {
-            DHCPMGR_LOG_WARNING("%s %d: no link-local address for %s in /proc/net/if_inet6 yet, waiting...\n",
+            DHCPMGR_LOG_WARNING("%s %d: no link-local address for %s in /proc/net/if_inet6 yet\n",
                                 __FUNCTION__, __LINE__, interfaceName);
         }
         else if (!tentative)
         {
-            break;  /* at least one link-local address is ready (DAD complete) */
+            break;
         }
         else
         {
-            DHCPMGR_LOG_WARNING("%s %d: interface still tentative: %s\n", __FUNCTION__, __LINE__, interfaceName);
+            DHCPMGR_LOG_WARNING("%s %d: interface %s link-local still tentative (DAD in progress)\n",
+                                __FUNCTION__, __LINE__, interfaceName);
         }
+
         usleep(INTF_V6LL_INTERVAL_IN_MSEC * USECS_IN_MSEC);
         waitTime -= INTF_V6LL_INTERVAL_IN_MSEC;
     }

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -457,10 +457,10 @@ static bool DhcpMgr_checkLinkLocalAddress(const char * interfaceName)
         FILE *fp_inet6 = fopen("/proc/net/if_inet6", "r");
         if (fp_inet6 != NULL)
         {
-            char addr[33];
-            unsigned int if_idx, pfx_len, scope, flags;
+            unsigned int scope, flags;
             char ifname[IF_NAMESIZE + 1];
-            while (fscanf(fp_inet6, "%32s %x %x %x %x %16s", addr, &if_idx, &pfx_len, &scope, &flags, ifname) == 6)
+            /* Suppress addr/if_idx/pfx_len with %* to avoid -Wunused-but-set-variable */
+            while (fscanf(fp_inet6, "%*s %*x %*x %x %x %16s", &scope, &flags, ifname) == 3)
             {
                 if (strcmp(ifname, interfaceName) != 0)
                     continue;   /* skip entries for other interfaces */
@@ -979,15 +979,24 @@ void* DhcpMgr_MainController( void *args )
 
     DHCPMGR_LOG_DEBUG("%s %d: Cleaning up DhcpMgr_MainController thread for interface %s\n", __FUNCTION__, __LINE__, inf_name);
     /*
-     * Hold q_mutex around mark_thread_stopped + mq_close so that
-     * DhcpMgr_OpenQueueEnsureThread (which also holds q_mutex while sending)
-     * cannot deliver a message to a queue that is already closed.
-     * Lock order: q_mutex -> global_mutex (same as in OpenQueueEnsureThread).
+     * Hold q_mutex around mark_thread_stopped + mq_close so that a concurrent
+     * DhcpMgr_OpenQueueEnsureThread cannot deliver a message to a queue that is
+     * already being closed. q_mutex is acquired here alone; global_mutex is not
+     * held across this section.
      */
-    DhcpMgr_LockInterfaceQueueMutexByName(inf_name);
-    mark_thread_stopped(inf_name);
-    mq_close(mq_desc);
-    DhcpMgr_UnlockInterfaceQueueMutexByName(inf_name);
+    if (DhcpMgr_LockInterfaceQueueMutexByName(inf_name) == 0)
+    {
+        mark_thread_stopped(inf_name);
+        mq_close(mq_desc);
+        DhcpMgr_UnlockInterfaceQueueMutexByName(inf_name);
+    }
+    else
+    {
+        DHCPMGR_LOG_ERROR("%s %d: Failed to acquire queue mutex for %s, attempting cleanup anyway\n",
+                          __FUNCTION__, __LINE__, inf_name);
+        mark_thread_stopped(inf_name);
+        mq_close(mq_desc);
+    }
     DHCPMGR_LOG_DEBUG("%s %d: Exiting DhcpMgr_MainController thread for mq %s\n", __FUNCTION__, __LINE__, mq_name);
     return NULL;
 

--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -976,7 +976,11 @@ void* DhcpMgr_MainController( void *args )
     {
         mark_thread_stopped(inf_name);
         mq_close(mq_desc);
-        DhcpMgr_UnlockInterfaceQueueMutexByName(inf_name);
+        if (DhcpMgr_UnlockInterfaceQueueMutexByName(inf_name) != 0)
+        {
+            DHCPMGR_LOG_ERROR("%s %d: Failed to unlock queue mutex for %s\n",
+                              __FUNCTION__, __LINE__, inf_name);
+        }
     }
     else
     {


### PR DESCRIPTION
## JIRA
[SHARMAN-4100]

## Problem
DHCPManager intermittently hangs and becomes completely unresponsive during IPv6 client startup. The process blocks indefinitely in `DhcpMgr_checkLinkLocalAddress`, preventing WAN recovery after a WAN down/up cycle or factory reset.

## Root Cause
`popen("ip address show dev <iface> tentative")` spawns a shell child process to check DAD (Duplicate Address Detection) status on the link-local address. The global `sigchld_handler` uses `waitpid(-1, WNOHANG)` which reaps **all** child processes indiscriminately. When it reaps the `popen` child before `pclose()` can, `pclose()` blocks indefinitely on its own `waitpid()` — hanging the DHCPManager thread permanently.

## Fix
Replace `popen`/`pclose` with a direct read of `/proc/net/if_inet6`:

- **No child process spawned** → zero SIGCHLD interference, no hang risk
- **Link-local only**: filters `scope == 0x20` (`IPV6_ADDR_LINKLOCAL`) — this function checks the link-local address DAD status required by DHCPv6
- **Per-address DAD check**: reads `IFA_F_TENTATIVE` flag (`0x40`) directly from the kernel's IPv6 address table
- **Three states per poll iteration**:
  - No link-local address present yet → keep waiting
  - Link-local found and tentative (DAD in progress) → keep waiting
  - Link-local found and non-tentative (DAD complete) → proceed with DHCPv6
- **fopen failure**: breaks out immediately rather than stalling until timeout

## Files Changed
- `source/DHCPMgrUtils/dhcpmgr_controller.c`
  - Added `#include <linux/if_addr.h>` for `IFA_F_TENTATIVE`
  - Added `#include <string.h>` for `strerror()`
  - Replaced `popen`/`fgets`/`pclose` with `fopen`/`fscanf`/`fclose` on `/proc/net/if_inet6`
  - Updated Doxygen doc comment to accurately describe the new implementation

## Test Procedure
1. Flash build with this fix on the device (XB8/XB7 or equivalent)
2. Trigger WAN down/up cycle repeatedly (minimum 10 times)
3. Verify DHCPManager does **not** hang after IPv6 client restart
4. Check `DHCPMGRLog.txt`:
   - `no link-local address for <iface> in /proc/net/if_inet6 yet` appears while waiting for LLA assignment
   - `interface still tentative` appears during DAD wait (if applicable)
   - DHCPv6 client starts successfully after DAD completes
5. Perform factory reset and verify WAN recovers correctly
6. Confirm no regression in DHCPv4/DHCPv6 lease acquisition
7. Verify DHCPManager process remains responsive throughout all cycles

## Verification
Fix verified on XB8 device — DHCPManager no longer hangs after multiple WAN down/up cycles (issue was previously reproducible within 2–3 cycles).