### PR TITLE
RDKB-65851: Fix DHCPv6 TimeOffset (suboption 38) hex parsing for correct timezone configuration

### DIFF
--- a/source/DHCPClientUtils/DHCPv6Client/dhcpv6_interface.h
+++ b/source/DHCPClientUtils/DHCPv6Client/dhcpv6_interface.h
@@ -84,7 +84,7 @@ typedef struct _DHCPv6_PLUGIN_MSG
     char domainName[BUFLEN_64];  /**< New domain Name,   */
     char ntpserver[BUFLEN_128];  /**< New ntp server(s), dhcp server may provide this */
     char aftr[AFTR_NAME_LENGTH];      /**< dhcp server may provide this */
-    uint32_t ipv6_TimeOffset; /**< New time offset */
+    uint32_t ipv6_TimeOffset; /**< New time offset (seconds, stored as 32-bit bit pattern of signed value) */
     struct _DHCPv6_PLUGIN_MSG  *next;  /** link to the next lease */
 }DHCPv6_PLUGIN_MSG;
 

--- a/source/DHCPMgrUtils/CustomOptions/dhcpmgr_custom_options.c
+++ b/source/DHCPMgrUtils/CustomOptions/dhcpmgr_custom_options.c
@@ -281,7 +281,7 @@ static int DhcpMgr_Option17Set_Common(const char *ifName, const char *OptionValu
                 unsigned int b0 = 0, b1 = 0, b2 = 0, b3 = 0;
                 if (sscanf(suboption_data, "%02x:%02x:%02x:%02x", &b0, &b1, &b2, &b3) == 4)
                 {
-                    /* Reconstruct 32-bit big-endian value; store bit pattern as uint32_t
+                    /* Reconstruct 32-bit value; store bit pattern as uint32_t
                      * (e.g. -18000 = 0xFFFFB9B0). Cast to int32_t when interpreting as signed. */
                     *ipv6_TimeOffset = ((uint32_t)b0 << 24) | ((uint32_t)b1 << 16) |
                                        ((uint32_t)b2 << 8)  |  (uint32_t)b3;

--- a/source/DHCPMgrUtils/CustomOptions/dhcpmgr_custom_options.c
+++ b/source/DHCPMgrUtils/CustomOptions/dhcpmgr_custom_options.c
@@ -276,10 +276,22 @@ static int DhcpMgr_Option17Set_Common(const char *ifName, const char *OptionValu
             } else if (strcmp(suboption, "38") == 0) 
             {
                 DHCPMGR_LOG_INFO("Suboption TimeOffset is %s in option %s\n", suboption_data, OptionValue);
-                *ipv6_TimeOffset = atoi(suboption_data);
-                DHCPMGR_LOG_INFO("ipv6_TimeOffset value is %u\n", *ipv6_TimeOffset);
-                //ifl_set_event("ipv6-timeoffset", suboption_data);
-                // Additional processing for TimeOffset can be added here
+                /* DHCPv6 TimeOffset (suboption 38) is a 32-bit signed big-endian value
+                 * transmitted as colon-separated hex bytes (e.g. "ff:ff:b9:b0" = -18000). */
+                unsigned int b0 = 0, b1 = 0, b2 = 0, b3 = 0;
+                if (sscanf(suboption_data, "%02x:%02x:%02x:%02x", &b0, &b1, &b2, &b3) == 4)
+                {
+                    /* Reconstruct 32-bit big-endian value; store bit pattern as uint32_t
+                     * (e.g. -18000 = 0xFFFFB9B0). Cast to int32_t when interpreting as signed. */
+                    *ipv6_TimeOffset = ((uint32_t)b0 << 24) | ((uint32_t)b1 << 16) |
+                                       ((uint32_t)b2 << 8)  |  (uint32_t)b3;
+                }
+                else
+                {
+                    DHCPMGR_LOG_ERROR("Failed to parse TimeOffset hex bytes: %s\n", suboption_data);
+                    *ipv6_TimeOffset = 0;
+                }
+                DHCPMGR_LOG_INFO("ipv6_TimeOffset value is %d seconds\n", (int32_t)*ipv6_TimeOffset);
             } else if (strcmp(suboption, "39") == 0) 
             {
                 DHCPMGR_LOG_INFO("Suboption IP Mode Preference is %s in option %s\n", suboption_data, OptionValue);


### PR DESCRIPTION
## Summary

**Jira:** RDKB-65851
**Issue:** LocalTime is not configured to PT/PST timezone

## Root Cause

The DHCPv6 vendor-specific TimeOffset (Option 17, suboption 38) is a 32-bit signed big-endian integer transmitted as colon-separated hex bytes (e.g. `ff:ff:b9:b0` = -18000 seconds = UTC-5). The previous implementation used `atoi()` to parse the value, which always returned `0` because `atoi()` cannot parse hex-colon formatted strings like `ff:ff:b9:b0`.

As a result, the time offset was never correctly applied, leaving the device timezone at UTC instead of the configured PT/PST.

## Fix

- Parse the 4 hex bytes using `sscanf()` with format `"%02x:%02x:%02x:%02x"`
- Reconstruct the 32-bit big-endian value using bit shifts
- Store as `uint32_t` (matching the `DHCP_MGR_IPV6_MSG` struct in `ipc_msg.h`)
- Cast to `int32_t` only when logging or interpreting as a signed offset
- Added error handling for malformed hex input (falls back to 0)

## Files Changed

- `source/DHCPClientUtils/DHCPv6Client/dhcpv6_interface.h` - Updated comment for `ipv6_TimeOffset` field
- `source/DHCPMgrUtils/CustomOptions/dhcpmgr_custom_options.c` - Replaced `atoi()` with proper hex byte parsing

## Example

| Input (hex bytes) | Reconstructed | Signed Value | Timezone |
|---|---|---|---|
| `ff:ff:b9:b0` | `0xFFFFB9B0` | -18000 sec | UTC-5 (EST) |
| `ff:ff:8f:80` | `0xFFFF8F80` | -28800 sec | UTC-8 (PST) |
| `00:00:00:00` | `0x00000000` | 0 sec | UTC |

## Test Procedure

### Pre-conditions
- Device under test (DUT) with DHCPv6 WAN connection
- CMTS/DHCP server configured to send Option 17 with suboption 38 (TimeOffset)
- Access to device console/SSH

### Steps

1. **Verify DHCPv6 Option 17 is received:**
   ```
   grep -i "TimeOffset\\|Option17\\|suboption.*38" /rdklogs/logs/DHCPMGRLog.txt.0
   ```
   Expected: Log shows `Suboption TimeOffset is ff:ff:8f:80` (or equivalent for configured timezone)

2. **Verify TimeOffset is correctly parsed:**
   ```
   grep "ipv6_TimeOffset value" /rdklogs/logs/DHCPMGRLog.txt.0
   ```
   Expected: `ipv6_TimeOffset value is -28800 seconds` (for PST)
   Before fix: `ipv6_TimeOffset value is 0`

3. **Verify device timezone is configured correctly:**
   ```
   date
   sysevent get ipv6-timeoffset
   ```
   Expected: Device time matches PT/PST timezone (UTC-8 / UTC-7 DST)

4. **Negative test - malformed input:**
   If suboption 38 contains invalid data, verify error log:
   ```
   grep "Failed to parse TimeOffset" /rdklogs/logs/DHCPMGRLog.txt.0
   ```
   Expected: Error logged and timeOffset defaults to 0 (no crash)

### Pass Criteria
- TimeOffset is correctly converted from hex bytes to signed integer
- Device local time reflects the configured timezone (PT/PST)
- No crashes or memory issues with valid or invalid input