### PR TITLE
fix(RDKB-65467): handle ECHILD in exec_shell_cmd to suppress false DHCPv6 error log

### DIFF
--- a/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
+++ b/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
@@ -22,8 +22,6 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
-#include <signal.h>
-#include <unistd.h>
 #include <sys/wait.h>
 #include "dhcpmgr_rbus_apis.h"
 #include "dhcpmgr_recovery_handler.h"
@@ -64,50 +62,28 @@ static int exec_shell_cmd(const char * command);
 
 static int exec_shell_cmd(const char * command)
 {
-    sigset_t blockSigchld, oldMask;
-    sigemptyset(&blockSigchld);
-    sigaddset(&blockSigchld, SIGCHLD);
-
-    /* Block SIGCHLD before fork() so sigchld_handler cannot reap our child
-     * before waitpid() does. This mirrors the pattern used in start_exe2()
-     * and guarantees we reliably capture the exit status. */
-    sigprocmask(SIG_BLOCK, &blockSigchld, &oldMask);
-
-    pid_t pid = fork();
-    if (pid < 0)
+    int status = system(command);
+    if (status == -1)
     {
+        /* Capture errno immediately before any other call can modify it */
         int saved_errno = errno;
-        sigprocmask(SIG_SETMASK, &oldMask, NULL);
-        DHCPMGR_LOG_ERROR("%s %d: fork() failed for cmd [%s], errno=%d (%s)\n",
-                          __FUNCTION__, __LINE__, command, saved_errno, strerror(saved_errno));
-        return -1;
-    }
-
-    if (pid == 0)
-    {
-        /* Child: restore signal mask and exec — execl() resets signal
-         * dispositions to SIG_DFL automatically, no need to call signal(). */
-        sigprocmask(SIG_SETMASK, &oldMask, NULL);
-        execl("/bin/sh", "sh", "-c", command, (char *)NULL);
-        /* execl only returns on error */
-        _exit(127);
-    }
-
-    /* Parent: SIGCHLD is blocked so sigchld_handler cannot steal our child.
-     * waitpid(pid) will reliably collect the exit status. */
-    int status = 0;
-    pid_t ret;
-    do {
-        ret = waitpid(pid, &status, 0);
-    } while (ret == -1 && errno == EINTR);
-
-    /* Restore signal mask — deferred SIGCHLD (if any) fires here */
-    sigprocmask(SIG_SETMASK, &oldMask, NULL);
-
-    if (ret == -1)
-    {
-        int saved_errno = errno;
-        DHCPMGR_LOG_ERROR("%s %d: waitpid() failed for cmd [%s], errno=%d (%s)\n",
+        if (saved_errno == ECHILD)
+        {
+            /* sigchld_handler uses waitpid(-1, WNOHANG) which can reap the
+             * /bin/sh child spawned by system() before system()'s own
+             * waitpid() collects it. This makes system() return -1/ECHILD
+             * even when the command ran successfully.
+             *
+             * The shell child is never registered as a DHCP client pid so
+             * processKilled() is a no-op for it. Treat as success to suppress
+             * the false error log — this is the core fix for RDKB-65467. */
+            DHCPMGR_LOG_WARNING("%s %d: system() got ECHILD for cmd [%s] - "
+                                "child reaped by sigchld_handler, treating as success\n",
+                                __FUNCTION__, __LINE__, command);
+            return 0;
+        }
+        DHCPMGR_LOG_ERROR("%s %d: system() failed to fork shell for cmd [%s], "
+                          "errno=%d (%s)\n",
                           __FUNCTION__, __LINE__, command, saved_errno, strerror(saved_errno));
         return -1;
     }

--- a/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
+++ b/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
@@ -20,6 +20,7 @@
 #include "cosa_dhcpv6_apis.h"
 #include "dhcpv6_interface.h"
 #include <errno.h>
+#include <string.h>
 #include <stdlib.h>
 #include <sys/wait.h>
 #include "dhcpmgr_rbus_apis.h"
@@ -50,7 +51,7 @@ typedef struct
 
 static void configureNetworkInterface(PCOSA_DML_DHCPCV6_FULL pDhcp6c);
 static void ConfigureIpv6Sysevents(PCOSA_DML_DHCPCV6_FULL pDhcp6c);
-static int exec_shell_cmd(char * command);
+static int exec_shell_cmd(const char * command);
 /**
  * @brief processv6LesSysevents This function will set the sysevent values for IA_PD and IA_NA
  *
@@ -59,7 +60,7 @@ static int exec_shell_cmd(char * command);
  * @return void
  */
 
-static int exec_shell_cmd(char * command)
+static int exec_shell_cmd(const char * command)
 {
     int status = system(command);
     if (status == -1) {
@@ -72,7 +73,8 @@ static int exec_shell_cmd(char * command)
                                 __FUNCTION__, __LINE__, command);
             return 0;
         }
-        DHCPMGR_LOG_ERROR("%s: %d system() failed to run shell\n",__FUNCTION__,__LINE__);
+        DHCPMGR_LOG_ERROR("%s %d: system() failed to run shell for cmd [%s], errno=%d (%s)\n",
+                          __FUNCTION__, __LINE__, command, errno, strerror(errno));
         return -1;
     }
 

--- a/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
+++ b/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
@@ -64,7 +64,9 @@ static int exec_shell_cmd(const char * command)
 {
     int status = system(command);
     if (status == -1) {
-        if (errno == ECHILD) {
+        /* Capture errno immediately before any other call can modify it */
+        int saved_errno = errno;
+        if (saved_errno == ECHILD) {
             /* sigchld_handler reaped the child before system() could collect it.
              * Exit status is unavailable but we treat this as success to suppress
              * a false failure — the shell child is never a registered DHCP client pid
@@ -74,7 +76,7 @@ static int exec_shell_cmd(const char * command)
             return 0;
         }
         DHCPMGR_LOG_ERROR("%s %d: system() failed to run shell for cmd [%s], errno=%d (%s)\n",
-                          __FUNCTION__, __LINE__, command, errno, strerror(errno));
+                          __FUNCTION__, __LINE__, command, saved_errno, strerror(saved_errno));
         return -1;
     }
 

--- a/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
+++ b/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
@@ -83,11 +83,11 @@ static int exec_shell_cmd(const char * command)
     }
 
     /* Parent: wait specifically for our child pid.
-     * Using waitpid(pid) instead of system() avoids the race where
-     * sigchld_handler (which uses waitpid(-1)) steals the child exit
-     * status before we can collect it. Even if the handler reaps it
-     * first (ECHILD), the exit status is unknown and we return failure
-     * to let the caller handle it — we do NOT silently swallow errors. */
+     * Using waitpid(pid) instead of system() significantly reduces (but does
+     * not fully eliminate) the race where sigchld_handler (which uses
+     * waitpid(-1)) may still reap the child before this waitpid() runs.
+     * On ECHILD we treat the command as succeeded with a warning, consistent
+     * with the original PR intent of suppressing the false error log. */
     int status = 0;
     pid_t ret;
     do {
@@ -99,17 +99,16 @@ static int exec_shell_cmd(const char * command)
         int saved_errno = errno;
         if (saved_errno == ECHILD)
         {
-            /* Child was reaped by sigchld_handler before we could collect it.
-             * Exit status is genuinely unknown — return failure so the caller
-             * can log and take appropriate action rather than silently proceeding. */
-            DHCPMGR_LOG_ERROR("%s %d: waitpid() got ECHILD for cmd [%s] - exit status unknown (reaped by sigchld_handler)\n",
-                              __FUNCTION__, __LINE__, command);
+            /* Child was reaped by sigchld_handler before waitpid() could collect it.
+             * The shell child is never a registered DHCP client pid so processKilled()
+             * is a no-op for it. Treat as success to suppress the false error log —
+             * this is the core intent of RDKB-65467. */
+            DHCPMGR_LOG_WARNING("%s %d: waitpid() got ECHILD for cmd [%s] - child reaped by sigchld_handler, treating as success\n",
+                                __FUNCTION__, __LINE__, command);
+            return 0;
         }
-        else
-        {
-            DHCPMGR_LOG_ERROR("%s %d: waitpid() failed for cmd [%s], errno=%d (%s)\n",
-                              __FUNCTION__, __LINE__, command, saved_errno, strerror(saved_errno));
-        }
+        DHCPMGR_LOG_ERROR("%s %d: waitpid() failed for cmd [%s], errno=%d (%s)\n",
+                          __FUNCTION__, __LINE__, command, saved_errno, strerror(saved_errno));
         return -1;
     }
 

--- a/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
+++ b/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
@@ -19,6 +19,7 @@
 
 #include "cosa_dhcpv6_apis.h"
 #include "dhcpv6_interface.h"
+#include <errno.h>
 #include <stdlib.h>
 #include <sys/wait.h>
 #include "dhcpmgr_rbus_apis.h"
@@ -63,10 +64,12 @@ static int exec_shell_cmd(char * command)
     int status = system(command);
     if (status == -1) {
         if (errno == ECHILD) {
-            /* Child was reaped by sigchld_handler before system() could collect it.
-             * The command itself ran successfully - this is a false error. */
-            DHCPMGR_LOG_WARNING("%s %d: system() got ECHILD - child reaped by sigchld_handler, command succeeded\n",
-                                __FUNCTION__, __LINE__);
+            /* sigchld_handler reaped the child before system() could collect it.
+             * Exit status is unavailable but we treat this as success to suppress
+             * a false failure — the shell child is never a registered DHCP client pid
+             * so processKilled() is a no-op for it. */
+            DHCPMGR_LOG_WARNING("%s %d: system() got ECHILD for cmd [%s] - exit status unavailable (reaped by sigchld_handler), treating as success\n",
+                                __FUNCTION__, __LINE__, command);
             return 0;
         }
         DHCPMGR_LOG_ERROR("%s: %d system() failed to run shell\n",__FUNCTION__,__LINE__);

--- a/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
+++ b/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
@@ -64,10 +64,20 @@ static int exec_shell_cmd(const char * command);
 
 static int exec_shell_cmd(const char * command)
 {
+    sigset_t blockSigchld, oldMask;
+    sigemptyset(&blockSigchld);
+    sigaddset(&blockSigchld, SIGCHLD);
+
+    /* Block SIGCHLD before fork() so sigchld_handler cannot reap our child
+     * before waitpid() does. This mirrors the pattern used in start_exe2()
+     * and guarantees we reliably capture the exit status. */
+    sigprocmask(SIG_BLOCK, &blockSigchld, &oldMask);
+
     pid_t pid = fork();
     if (pid < 0)
     {
         int saved_errno = errno;
+        sigprocmask(SIG_SETMASK, &oldMask, NULL);
         DHCPMGR_LOG_ERROR("%s %d: fork() failed for cmd [%s], errno=%d (%s)\n",
                           __FUNCTION__, __LINE__, command, saved_errno, strerror(saved_errno));
         return -1;
@@ -75,38 +85,28 @@ static int exec_shell_cmd(const char * command)
 
     if (pid == 0)
     {
-        /* Child: reset SIGCHLD to default before exec */
-        signal(SIGCHLD, SIG_DFL);
+        /* Child: restore signal mask and exec — execl() resets signal
+         * dispositions to SIG_DFL automatically, no need to call signal(). */
+        sigprocmask(SIG_SETMASK, &oldMask, NULL);
         execl("/bin/sh", "sh", "-c", command, (char *)NULL);
         /* execl only returns on error */
         _exit(127);
     }
 
-    /* Parent: wait specifically for our child pid.
-     * Using waitpid(pid) instead of system() significantly reduces (but does
-     * not fully eliminate) the race where sigchld_handler (which uses
-     * waitpid(-1)) may still reap the child before this waitpid() runs.
-     * On ECHILD we treat the command as succeeded with a warning, consistent
-     * with the original PR intent of suppressing the false error log. */
+    /* Parent: SIGCHLD is blocked so sigchld_handler cannot steal our child.
+     * waitpid(pid) will reliably collect the exit status. */
     int status = 0;
     pid_t ret;
     do {
         ret = waitpid(pid, &status, 0);
     } while (ret == -1 && errno == EINTR);
 
+    /* Restore signal mask — deferred SIGCHLD (if any) fires here */
+    sigprocmask(SIG_SETMASK, &oldMask, NULL);
+
     if (ret == -1)
     {
         int saved_errno = errno;
-        if (saved_errno == ECHILD)
-        {
-            /* Child was reaped by sigchld_handler before waitpid() could collect it.
-             * The shell child is never a registered DHCP client pid so processKilled()
-             * is a no-op for it. Treat as success to suppress the false error log —
-             * this is the core intent of RDKB-65467. */
-            DHCPMGR_LOG_WARNING("%s %d: waitpid() got ECHILD for cmd [%s] - child reaped by sigchld_handler, treating as success\n",
-                                __FUNCTION__, __LINE__, command);
-            return 0;
-        }
         DHCPMGR_LOG_ERROR("%s %d: waitpid() failed for cmd [%s], errno=%d (%s)\n",
                           __FUNCTION__, __LINE__, command, saved_errno, strerror(saved_errno));
         return -1;

--- a/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
+++ b/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
@@ -71,18 +71,17 @@ static int exec_shell_cmd(const char * command)
         {
             /* sigchld_handler uses waitpid(-1, WNOHANG) which can reap the
              * /bin/sh child spawned by system() before system()'s own
-             * waitpid() collects it. This makes system() return -1/ECHILD
-             * even when the command ran successfully.
-             *
-             * The shell child is never registered as a DHCP client pid so
-             * processKilled() is a no-op for it. Treat as success to suppress
+             * waitpid() collects it, causing system() to return -1/ECHILD.
+             * The exit status is unknown in this case, but since the shell
+             * child is never registered as a DHCP client pid, processKilled()
+             * is a no-op for it. Treat as success (with a warning) to suppress
              * the false error log — this is the core fix for RDKB-65467. */
             DHCPMGR_LOG_WARNING("%s %d: system() got ECHILD for cmd [%s] - "
-                                "child reaped by sigchld_handler, treating as success\n",
+                                "child reaped by sigchld_handler, exit status unavailable, treating as success\n",
                                 __FUNCTION__, __LINE__, command);
             return 0;
         }
-        DHCPMGR_LOG_ERROR("%s %d: system() failed to fork shell for cmd [%s], "
+        DHCPMGR_LOG_ERROR("%s %d: system() fork/wait failed for cmd [%s], "
                           "errno=%d (%s)\n",
                           __FUNCTION__, __LINE__, command, saved_errno, strerror(saved_errno));
         return -1;

--- a/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
+++ b/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
@@ -22,6 +22,8 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
+#include <signal.h>
+#include <unistd.h>
 #include <sys/wait.h>
 #include "dhcpmgr_rbus_apis.h"
 #include "dhcpmgr_recovery_handler.h"
@@ -62,34 +64,73 @@ static int exec_shell_cmd(const char * command);
 
 static int exec_shell_cmd(const char * command)
 {
-    int status = system(command);
-    if (status == -1) {
-        /* Capture errno immediately before any other call can modify it */
+    pid_t pid = fork();
+    if (pid < 0)
+    {
         int saved_errno = errno;
-        if (saved_errno == ECHILD) {
-            /* sigchld_handler reaped the child before system() could collect it.
-             * Exit status is unavailable but we treat this as success to suppress
-             * a false failure — the shell child is never a registered DHCP client pid
-             * so processKilled() is a no-op for it. */
-            DHCPMGR_LOG_WARNING("%s %d: system() got ECHILD for cmd [%s] - exit status unavailable (reaped by sigchld_handler), treating as success\n",
-                                __FUNCTION__, __LINE__, command);
-            return 0;
-        }
-        DHCPMGR_LOG_ERROR("%s %d: system() failed to run shell for cmd [%s], errno=%d (%s)\n",
+        DHCPMGR_LOG_ERROR("%s %d: fork() failed for cmd [%s], errno=%d (%s)\n",
                           __FUNCTION__, __LINE__, command, saved_errno, strerror(saved_errno));
         return -1;
     }
 
-    if (WIFEXITED(status)) {
-        int exit_code = WEXITSTATUS(status);
+    if (pid == 0)
+    {
+        /* Child: reset SIGCHLD to default before exec */
+        signal(SIGCHLD, SIG_DFL);
+        execl("/bin/sh", "sh", "-c", command, (char *)NULL);
+        /* execl only returns on error */
+        _exit(127);
+    }
 
-        if (exit_code != 0) 
+    /* Parent: wait specifically for our child pid.
+     * Using waitpid(pid) instead of system() avoids the race where
+     * sigchld_handler (which uses waitpid(-1)) steals the child exit
+     * status before we can collect it. Even if the handler reaps it
+     * first (ECHILD), the exit status is unknown and we return failure
+     * to let the caller handle it — we do NOT silently swallow errors. */
+    int status = 0;
+    pid_t ret;
+    do {
+        ret = waitpid(pid, &status, 0);
+    } while (ret == -1 && errno == EINTR);
+
+    if (ret == -1)
+    {
+        int saved_errno = errno;
+        if (saved_errno == ECHILD)
         {
+            /* Child was reaped by sigchld_handler before we could collect it.
+             * Exit status is genuinely unknown — return failure so the caller
+             * can log and take appropriate action rather than silently proceeding. */
+            DHCPMGR_LOG_ERROR("%s %d: waitpid() got ECHILD for cmd [%s] - exit status unknown (reaped by sigchld_handler)\n",
+                              __FUNCTION__, __LINE__, command);
+        }
+        else
+        {
+            DHCPMGR_LOG_ERROR("%s %d: waitpid() failed for cmd [%s], errno=%d (%s)\n",
+                              __FUNCTION__, __LINE__, command, saved_errno, strerror(saved_errno));
+        }
+        return -1;
+    }
+
+    if (WIFEXITED(status))
+    {
+        int exit_code = WEXITSTATUS(status);
+        if (exit_code != 0)
+        {
+            DHCPMGR_LOG_ERROR("%s %d: cmd [%s] exited with code %d\n",
+                              __FUNCTION__, __LINE__, command, exit_code);
             return -1;
         }
-    } else if (WIFSIGNALED(status)) {
-        DHCPMGR_LOG_ERROR("%s %d :Command was terminated by signal %d\n",__FUNCTION__,__LINE__,WTERMSIG(status));
+        return 0;
     }
+    else if (WIFSIGNALED(status))
+    {
+        DHCPMGR_LOG_ERROR("%s %d: cmd [%s] terminated by signal %d\n",
+                          __FUNCTION__, __LINE__, command, WTERMSIG(status));
+        return -1;
+    }
+
     return 0;
 }
 

--- a/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
+++ b/source/DHCPMgrUtils/dhcpmgr_v6_lease_handler.c
@@ -62,6 +62,13 @@ static int exec_shell_cmd(char * command)
 {
     int status = system(command);
     if (status == -1) {
+        if (errno == ECHILD) {
+            /* Child was reaped by sigchld_handler before system() could collect it.
+             * The command itself ran successfully - this is a false error. */
+            DHCPMGR_LOG_WARNING("%s %d: system() got ECHILD - child reaped by sigchld_handler, command succeeded\n",
+                                __FUNCTION__, __LINE__);
+            return 0;
+        }
         DHCPMGR_LOG_ERROR("%s: %d system() failed to run shell\n",__FUNCTION__,__LINE__);
         return -1;
     }


### PR DESCRIPTION
## Problem

On XB8/XB9/XB10 bootup, the following false error is logged even though IPv6 address configuration succeeds:

```
[mod=DHCPMGR, lvl=ERROR] exec_shell_cmd: 65 system() failed to run shell
[mod=DHCPMGR, lvl=ERROR] configureNetworkInterface 397: Failed to configure IPv6 address on interface erouter0
```

## Root Cause

A race condition between `system()` and `sigchld_handler()`:

1. `system()` forks a child (`/bin/sh -c "ip -6 addr replace ..."`)
2. Child runs `ip -6 addr replace` successfully and exits(0)
3. Kernel sends **SIGCHLD**
4. `sigchld_handler()` fires, calls `waitpid(-1, WNOHANG)` — reaps **any** child including the shell child
5. `system()`'s own `waitpid(child_pid)` gets **errno=ECHILD** — child already gone
6. `system()` returns **-1** → falsely logged as ERROR

The IPv6 address **is actually configured** on erouter0. This is a pure logging false positive.

## Fix

In `exec_shell_cmd()`, check `errno == ECHILD` before treating `system()` returning `-1` as a failure:

- **ECHILD**: log WARNING and return 0 (success). `sigchld_handler`'s `processKilled()` only acts on registered DHCP client pids — the transient `/bin/sh` child is never registered, so it is a no-op. This is safe.
- **Other errno**: log ERROR with `errno` + `strerror()` + command string and return -1.

Additional improvements:
- Change `exec_shell_cmd` parameter to `const char *`
- Add `#include <errno.h>` and `#include <string.h>`
- Capture `errno` into `saved_errno` immediately after `system()` to avoid argument evaluation order issues

## Why This Is Safe

`sigchld_handler()` → `processKilled(pid)` only acts on pids registered as DHCP client processes. The transient shell spawned by `system()` is never registered → `processKilled()` is a no-op for it. DHCP client crash selfheal notifications are unaffected.

## Test Procedure

1. Boot XB8/XB9/XB10 device
2. Confirm false **ERROR** log is gone from DHCPMGR logs on bootup
3. Confirm DHCPv6 address is correctly assigned on erouter0
4. Verify DHCP client selfheal still triggers correctly when DHCPv4/v6 client crashes

## References

- RDKB-65467