### PR TITLE
RDKB-64552: DHCP Lease Expire Time IPV4 is not getting updated in GUI

### DIFF
--- a/source/TR-181/middle_layer_src/Makefile.am
+++ b/source/TR-181/middle_layer_src/Makefile.am
@@ -37,4 +37,4 @@ libCcspDhcpMgr_middle_layer_src_la_CPPFLAGS = -I$(top_srcdir)/source/TR-181/incl
                                               -I$(top_srcdir)/source/DHCPClientUtils/DHCPv6Server/include
 
 libCcspDhcpMgr_middle_layer_src_la_SOURCES = cosa_dhcpv4_internal.c cosa_dhcpv6_internal.c plugin_main.c cosa_apis_util.c cosa_dhcpv4_dml.c cosa_dhcpv6_dml.c cosa_webconfig_api.c cosa_x_cisco_com_devicecontrol_internal.c dhcpmgr_rbus_apis.c
-libCcspDhcpMgr_middle_layer_src_la_LDFLAGS = -lccsp_common -lsyscfg -lsysevent -lsecure_wrapper -ltelemetry_msgsender
+libCcspDhcpMgr_middle_layer_src_la_LDFLAGS = -lccsp_common -lsyscfg -lsysevent -lsecure_wrapper -ltelemetry_msgsender -lapi_dhcpv4c

--- a/source/TR-181/middle_layer_src/cosa_dhcpv4_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_dhcpv4_dml.c
@@ -89,7 +89,7 @@
 
 #include <syscfg/syscfg.h>
 #include "dhcp_client_common_utils.h"
-#include <ccsp/dhcpv4c_api.h>
+#include <dhcpv4c_api.h>
 
 extern void* g_pDslhDmlAgent;
 extern ANSC_HANDLE g_Dhcpv4Object;
@@ -809,7 +809,9 @@ Client_GetParamIntValue
     if (strcmp(ParamName, "LeaseTimeRemaining") == 0)
     {
         /* collect value */
-        dhcpv4c_get_ert_remain_lease_time((UINT*)&pDhcpc->Info.LeaseTimeRemaining);
+        UINT leaseTimeRemaining = 0;
+        dhcpv4c_get_ert_remain_lease_time(&leaseTimeRemaining);
+        pDhcpc->Info.LeaseTimeRemaining = (int)leaseTimeRemaining;
         *pInt   = pDhcpc->Info.LeaseTimeRemaining;
 
         return TRUE;

--- a/source/TR-181/middle_layer_src/cosa_dhcpv4_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_dhcpv4_dml.c
@@ -89,6 +89,7 @@
 
 #include <syscfg/syscfg.h>
 #include "dhcp_client_common_utils.h"
+#include <ccsp/dhcpv4c_api.h>
 
 extern void* g_pDslhDmlAgent;
 extern ANSC_HANDLE g_Dhcpv4Object;
@@ -808,8 +809,7 @@ Client_GetParamIntValue
     if (strcmp(ParamName, "LeaseTimeRemaining") == 0)
     {
         /* collect value */
-        CosaDmlDhcpcGetInfo(NULL, pCxtLink->InstanceNumber, &pDhcpc->Info);
-
+        dhcpv4c_get_ert_remain_lease_time((UINT*)&pDhcpc->Info.LeaseTimeRemaining);
         *pInt   = pDhcpc->Info.LeaseTimeRemaining;
 
         return TRUE;


### PR DESCRIPTION
Reason for change: DHCP Lease Expire Time IPV4 is not getting updated in GUI Test Procedure: Verify the ipv4 dhcp lease time in gui and dmcli cmd output Risks: Low
Priority: P1
Signed-off-by:Jayajothi_Gopi@comcast.com