### PR TITLE
XER10-3139 : Fix controller thread exit race losing queued messages

### DIFF
--- a/source/DHCPMgrUtils/dhcpmgr_controller.c
+++ b/source/DHCPMgrUtils/dhcpmgr_controller.c
@@ -942,21 +942,19 @@ void* DhcpMgr_MainController( void *args )
         {
             if (errno == EAGAIN)
             {
-                /* No message yet, wait 250ms */
-                usleep(sleep_us);
-                DHCPMGR_LOG_DEBUG("%s %d: mq_receive timeout, no message received yet on %s with retry count %d\n",__FUNCTION__, __LINE__, mq_name, retry_count);
-                retry_count++;
-
-                if (retry_count >= max_retries)
+                if (retry_count > max_retries)
                 {
                     DHCPMGR_LOG_DEBUG("%s %d: mq_receive timeout after 5s on %s\n",__FUNCTION__, __LINE__, mq_name);
                     if(DhcpMgr_LockInterfaceQueueMutexByName(inf_name) != 0) // lock the mutex
                     {
                         DHCPMGR_LOG_ERROR("%s %d Failed to lock interface queue mutex for %s\n", __FUNCTION__, __LINE__, inf_name);
                     }
-                    break; // exit thread after timeout
+                    break; // queue truly empty under lock, safe to exit thread
                 }
-
+                 /* No message yet, wait 250ms */
+                usleep(sleep_us);
+                DHCPMGR_LOG_DEBUG("%s %d: mq_receive timeout, no message received yet on %s with retry count %d\n",__FUNCTION__, __LINE__, mq_name, retry_count);
+                retry_count++;
                 continue; // retry loop
             }
             else


### PR DESCRIPTION
Reason for change: Fix a race condition in DhcpMgr_MainController where queued DHCP messages are permanently lost when the controller thread exits on idle timeout. The previous final-drain-under-mutex pattern could miss messages posted during the usleep() window, and duplicated dispatch logic inline in the timeout path.

Test Procedure: 1. Bring up WAN interface on XER10, verify DHCPv4/v6 completes and no unexpected thread exits appear in DHCPMGRLog.txt. 2. Remove WAN interface after DHCP completes, verify controller thread exits cleanly after ~5s with mq_receive timeout log and no deadlock. 3. Send rapid DHCP events near the idle timeout boundary, verify all events are processed with no message loss. 4. Bring up multiple WAN interfaces simultaneously, verify independent controller threads with no cross-interface interference.

Risks: Low

Priority: P3

Signed-off-by: Aadhithan_PE@comcast.com