### PR TITLE
RDKB-65988: Remove PSID derivation from DHCPManager MAP parsing and source legacy MAP DML from sysevent

### DIFF
--- a/source/DHCPMgrUtils/dhcpmgr_map_apis.c
+++ b/source/DHCPMgrUtils/dhcpmgr_map_apis.c
@@ -200,6 +200,7 @@ CosaDmlMapParseResponse
 
                g_stMapData.Ratio = 1 << (g_stMapData.EaLen -
                                                     (BUFLEN_32 - g_stMapData.RuleIPv4PrefixLen));
+
                /*
                 * RFC default for PSID offset applies when the optional
                 * S46 Port Params suboption is not present. Keep the default
@@ -405,177 +406,6 @@ CosaDmlMapConvertStringToHexStream
   return STATUS_SUCCESS;
 }
 
-static inline uint64_t bitmask(unsigned n)
-{
-    if (n == 0)  return 0;
-    if (n >= 64) return UINT64_MAX;
-    return (UINT64_C(1) << n) - 1;
-}
-
-/*
-                :           :           ___/       :
-                |  p bits   |          /  q bits   :
-                +-----------+         +------------+
-                |IPv4 suffix|         |Port Set ID |
-                +-----------+         +------------+
-                 \          /    ____/    ________/
-                   \       :  __/   _____/
-                     \     : /     /
- |     n bits         |  o bits   | s bits  |   128-n-o-s bits      |
- +--------------------+-----------+---------+------------+----------+
- |  Rule IPv6 prefix  |  EA bits  |subnet ID|     interface ID      |
- +--------------------+-----------+---------+-----------------------+
- |<---  End-user IPv6 prefix  --->|
-
-EA-bits:
-+-------------------+---------+
-|IPV4 Address Suffix|   PSID  |
-+-------------------+---------+
-|--------p----------|----q----+
-|--------------o--------------|
-*/
-
-static RETURN_STATUS
-CosaDmlMapComputePsidAndIPv4Suffix
-(
-    PCHAR          pPdIPv6Prefix,
-    UINT16         pdPrefixLen,
-    UINT16         v6PrefixLen,
-    UINT16         v4PrefixLen,
-    PUINT16        pPsid,
-    PUINT16        pPsidLen,
-    PUINT32        pIPv4Suffix
-)
-{
-  struct in6_addr ipv6Addr;
-
-  MAP_LOG_INFO("Entry");
-
-  if (!pPdIPv6Prefix || !pPsid || !pPsidLen || !pIPv4Suffix)
-  {
-      MAP_LOG_ERROR("NULL parameter passed to MAP EA computation");
-      return STATUS_FAILURE;
-  }
-
-  if ( pdPrefixLen < v6PrefixLen )
-  {
-      MAP_LOG_ERROR("Invalid MAP option, PD Prefix(%d) < IPv6 Prefix(%d)",
-               pdPrefixLen, v6PrefixLen);
-      return STATUS_FAILURE;
-  }
-
-  if (pdPrefixLen > 128 || v6PrefixLen > 128)
-  {
-      MAP_LOG_ERROR("Invalid IPv6 prefix length: pdPrefixLen=%u v6PrefixLen=%u",
-              pdPrefixLen, v6PrefixLen);
-      return STATUS_FAILURE;
-  }
-
-  if ( inet_pton(AF_INET6, pPdIPv6Prefix, &ipv6Addr) <= 0 )
-  {
-      MAP_LOG_ERROR("Invalid IPv6 address = %s", pPdIPv6Prefix);
-      return STATUS_FAILURE;
-  }
-
-  if (g_stMapData.EaLen > 0)
-  {
-      UINT8 v4SuffixBitsLen = 0;
-      UINT8 psidBitsLen = 0;
-      UINT8 eaBitsLen = 0 ;
-
-      if (v4PrefixLen > BUFLEN_32)
-      {
-          MAP_LOG_ERROR("Invalid IPv4 prefix length %u (must be <= 32)", v4PrefixLen);
-          return STATUS_FAILURE;
-      }
-      // V4 suffix bits length
-      v4SuffixBitsLen = BUFLEN_32 - v4PrefixLen;
-
-      // EA bits length
-      eaBitsLen = pdPrefixLen - v6PrefixLen;
-
-      if (eaBitsLen < v4SuffixBitsLen)
-      {
-          MAP_LOG_ERROR("Invalid MAP rule: EA bits length %u is smaller than IPv4 suffix bits length %u", eaBitsLen, v4SuffixBitsLen);
-          return STATUS_FAILURE;
-      }
-
-      // PSID length
-      psidBitsLen = eaBitsLen - v4SuffixBitsLen;
-
-      MAP_LOG_INFO("Calculated EA bits length   : %u", eaBitsLen);
-      MAP_LOG_INFO("IPv4 suffix bits length (p) : %u", v4SuffixBitsLen);
-      MAP_LOG_INFO("PSID bits length (q)        : %u", psidBitsLen);
-
-      if (eaBitsLen != g_stMapData.EaLen)
-      {
-          MAP_LOG_ERROR("Calculated EA-bits and received MAP EA-bits does not match!");
-          return STATUS_FAILURE;
-      }
-
-      if (eaBitsLen > 64)
-      {
-          MAP_LOG_ERROR("EA bits length %u exceeds supported limit (64 bits)", eaBitsLen);
-          return STATUS_FAILURE;
-      }
-
-      if (psidBitsLen > 16)
-      {
-          MAP_LOG_ERROR("Invalid PSID length %u (must be <= 16)", psidBitsLen);
-          return STATUS_FAILURE;
-      }
-
-      /*
-       * Extract EA bits MSB-first from IPv6 delegated prefix
-       */
-      uint64_t eaBits = 0;
-      UINT8 bitPos = v6PrefixLen;
-      for (unsigned i = 0; i < eaBitsLen; i++)
-      {
-          UINT8 byteIndex = bitPos / 8;
-          UINT8 bitIndex = 7 - (bitPos % 8);
-          eaBits = (eaBits << 1) | ((ipv6Addr.s6_addr[byteIndex] >> bitIndex) & 0x01);
-          bitPos++;
-      }
-
-      MAP_LOG_INFO("Extracted EA bits : 0x%llX", (unsigned long long)eaBits);
-
-      /*
-       * Split EA bits into IPv4 suffix and PSID
-       */
-      if (v4SuffixBitsLen > 0)
-      {
-          *pIPv4Suffix = (eaBits >> psidBitsLen) & bitmask(v4SuffixBitsLen);
-      } 
-      else 
-      {
-          *pIPv4Suffix = 0;
-          MAP_LOG_INFO("No IPv4 suffix bits, set to 0");
-      }
-
-      if (psidBitsLen > 0)
-      {
-          *pPsid = eaBits & bitmask(psidBitsLen);
-      }
-      else
-      {
-          *pPsid = 0;
-          MAP_LOG_INFO("No PSID bits, set to 0");
-      }
-
-      *pPsidLen = psidBitsLen;
-
-      MAP_LOG_INFO("Computed IPv4 Suffix : %u", *pIPv4Suffix);
-      MAP_LOG_INFO("Computed PSID        : %u", *pPsid);
-      MAP_LOG_INFO("Computed PSID Length : %u", *pPsidLen);
-  }
-  else
-  {
-      MAP_LOG_INFO("EA bits not set, using PSID/PSIDLen from received OPTION_S46_PORT_PARAM");
-  }
-  return STATUS_SUCCESS;
-}
-
 /**
  * @brief Parses the MAPE/MAPT options 94 & 95 response respectively.
  *
@@ -625,21 +455,6 @@ ANSC_STATUS DhcpMgr_MapParseOptResponse
   if ( !ret && CosaDmlMapParseResponse (pOptionBuf, uiOptionBufLen) != STATUS_SUCCESS )
   {
        MAP_LOG_ERROR("MAP Parsing Response Failed !!");
-       ret = STATUS_FAILURE;
-  }
-
-    /* validate MAPT/MAPE response */
-  if ( !ret && CosaDmlMapComputePsidAndIPv4Suffix ( g_stMapData.PdIPv6Prefix
-                                                   , g_stMapData.PdIPv6PrefixLen
-                                                   , g_stMapData.RuleIPv6PrefixLen
-                                                   , g_stMapData.RuleIPv4PrefixLen
-                                                   , &g_stMapData.Psid
-                                                   , &g_stMapData.PsidLen
-                                                   , &g_stMapData.IPv4Suffix
-                                                  ) != STATUS_SUCCESS )
-  {
-       MAP_LOG_ERROR("MAP Psid and IPv4 Suffix Computation Failed !!");
-       memset (&g_stMapData, 0, sizeof(g_stMapData));
        ret = STATUS_FAILURE;
   }
 

--- a/source/TR-181/middle_layer_src/cosa_dhcpv6_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_dhcpv6_dml.c
@@ -77,6 +77,7 @@
 #include "util.h"
 
 #include <stdlib.h>
+#include <strings.h>
 #include <unistd.h>
 
 #define MIN 60
@@ -3292,21 +3293,17 @@ dhcp6c_mapt_mape_GetParamBoolValue
         BOOL*                       pBool
     )
 {
+    (void)hInsContext;
+    char temp[16] = {0};
 
-    PCOSA_CONTEXT_DHCPCV6_LINK_OBJECT pCxtLink        = (PCOSA_CONTEXT_DHCPCV6_LINK_OBJECT)hInsContext;
-    PCOSA_DML_DHCPCV6_FULL            pDhcpc          = (PCOSA_DML_DHCPCV6_FULL)pCxtLink->hContext;
-      
-    const DML_DHCPCV6_MAP_INFO    *MapInfo = &(pDhcpc->Info.MapInfo);
     /* check the parameter name and return the corresponding value */
     if (strcmp(ParamName, "MapIsFMR") == 0)
     {
-        if(MapInfo->MaptAssigned || MapInfo->MapeAssigned)
+        *pBool = FALSE;
+        if (commonSyseventGet(SYSEVENT_MAP_IS_FMR, temp, sizeof(temp)) == 0)
         {
-                *pBool  = MapInfo->IsFMR;
+            *pBool = (strcasecmp(temp, "TRUE") == 0) ? TRUE : FALSE;
         }
-        else
-            *pBool  = FALSE;
-
         return TRUE;
     }
 
@@ -3351,53 +3348,83 @@ dhcp6c_mapt_mape_GetParamUlongValue
         ULONG*                      puLong
     )
 {
-    PCOSA_CONTEXT_DHCPCV6_LINK_OBJECT pCxtLink        = (PCOSA_CONTEXT_DHCPCV6_LINK_OBJECT)hInsContext;
-    PCOSA_DML_DHCPCV6_FULL            pDhcpc          = (PCOSA_DML_DHCPCV6_FULL)pCxtLink->hContext;
-      
-    const DML_DHCPCV6_MAP_INFO    *MapInfo = &(pDhcpc->Info.MapInfo);
+    (void)hInsContext;
+    char temp[64] = {0};
+    char* endPtr = NULL;
+
     *puLong = 0; /* default value */
     /* check the parameter name and return the corresponding value */
     if (strcmp(ParamName, "MapEALen") == 0)
     {
-        if(MapInfo->MaptAssigned || MapInfo->MapeAssigned)
+        if (commonSyseventGet(SYSEVENT_MAP_EA_LEN, temp, sizeof(temp)) == 0)
         {
-           *puLong  = MapInfo->MapEALen;
+            errno = 0;
+            *puLong = strtoul(temp, &endPtr, 10);
+            if (errno != 0 || endPtr == temp)
+            {
+                DHCPMGR_LOG_ERROR("%s: invalid numeric value '%s' for %s", __FUNCTION__, temp, SYSEVENT_MAP_EA_LEN);
+                *puLong = 0;
+            }
         }
         return TRUE;
     }
 
     if (strcmp(ParamName, "MapPSIDOffset") == 0)
     {
-        if(MapInfo->MaptAssigned || MapInfo->MapeAssigned)
+        if (commonSyseventGet(SYSEVENT_MAPT_PSID_OFFSET, temp, sizeof(temp)) == 0)
         {
-           *puLong  = MapInfo->MapPSIDOffset;
+            errno = 0;
+            *puLong = strtoul(temp, &endPtr, 10);
+            if (errno != 0 || endPtr == temp)
+            {
+                DHCPMGR_LOG_ERROR("%s: invalid numeric value '%s' for %s", __FUNCTION__, temp, SYSEVENT_MAPT_PSID_OFFSET);
+                *puLong = 0;
+            }
         }
         return TRUE;
     }
 
     if (strcmp(ParamName, "MapPSIDLen") == 0)
     {
-        if(MapInfo->MaptAssigned || MapInfo->MapeAssigned)
+        if (commonSyseventGet(SYSEVENT_MAPT_PSID_LENGTH, temp, sizeof(temp)) == 0)
         {
-           *puLong  = MapInfo->MapPSIDLen;
+            errno = 0;
+            *puLong = strtoul(temp, &endPtr, 10);
+            if (errno != 0 || endPtr == temp)
+            {
+                DHCPMGR_LOG_ERROR("%s: invalid numeric value '%s' for %s", __FUNCTION__, temp, SYSEVENT_MAPT_PSID_LENGTH);
+                *puLong = 0;
+            }
         }
         return TRUE;
     }
 
     if (strcmp(ParamName, "MapPSID") == 0)
     {
-        if(MapInfo->MaptAssigned || MapInfo->MapeAssigned)
+        if (commonSyseventGet(SYSEVENT_MAPT_PSID_VALUE, temp, sizeof(temp)) == 0)
         {
-           *puLong  = MapInfo->MapPSIDValue;
+            errno = 0;
+            *puLong = strtoul(temp, &endPtr, 10);
+            if (errno != 0 || endPtr == temp)
+            {
+                DHCPMGR_LOG_ERROR("%s: invalid numeric value '%s' for %s", __FUNCTION__, temp, SYSEVENT_MAPT_PSID_VALUE);
+                *puLong = 0;
+            }
         }
         return TRUE;
     }
 
     if (strcmp(ParamName, "MapRatio") == 0)
     {
-        if(MapInfo->MaptAssigned || MapInfo->MapeAssigned)
+        if (commonSyseventGet(SYSEVENT_MAPT_RATIO, temp, sizeof(temp)) == 0)
         {
-           *puLong  = MapInfo->MapRatio;
+            errno = 0;
+            *puLong = strtoul(temp, &endPtr, 10);
+            if (errno != 0 || endPtr == temp)
+            {
+                DHCPMGR_LOG_ERROR("%s: invalid numeric value '%s' for %s", __FUNCTION__, temp, SYSEVENT_MAPT_RATIO);
+                *puLong = 0;
+            }
         }
         return TRUE;
     }
@@ -3452,28 +3479,19 @@ dhcp6c_mapt_mape_GetParamStringValue
         ULONG*                      pUlSize
     )
 {
-    PCOSA_CONTEXT_DHCPCV6_LINK_OBJECT pCxtLink        = (PCOSA_CONTEXT_DHCPCV6_LINK_OBJECT)hInsContext;
-    PCOSA_DML_DHCPCV6_FULL            pDhcpc          = (PCOSA_DML_DHCPCV6_FULL)pCxtLink->hContext;
-      
-    const DML_DHCPCV6_MAP_INFO    *MapInfo = &(pDhcpc->Info.MapInfo);
+    (void)hInsContext;
+
+    char temp[256] = {0};
     AnscCopyString(pValue, ""); // default value
 
     /* check the parameter name and return the corresponding value */
     if (strcmp(ParamName, "MapTransportMode") == 0)
     {
-        char *temp;
-        if( MapInfo->MaptAssigned )
+        if (commonSyseventGet(SYSEVENT_MAP_TRANSPORT_MODE, temp, sizeof(temp)) != 0 || temp[0] == '\0')
         {
-            temp = "MAPT";
+            snprintf(temp, sizeof(temp), "%s", "NONE");
         }
-        else if( MapInfo->MapeAssigned )
-        {
-            temp = "MAPE";
-        }
-        else
-        {
-            temp = "NONE";
-        }
+
         if ( AnscSizeOfString(temp) < *pUlSize)
         {
             AnscCopyString(pValue, temp);
@@ -3488,53 +3506,52 @@ dhcp6c_mapt_mape_GetParamStringValue
 
     if (strcmp(ParamName, "MapBRPrefix") == 0)
     {
-
-        if ( AnscSizeOfString((const char *)MapInfo->MapBRPrefix) < *pUlSize)
+        (void)commonSyseventGet(SYSEVENT_MAP_BR_IPV6_PREFIX, temp, sizeof(temp));
+        if ( AnscSizeOfString(temp) < *pUlSize)
         {
-            AnscCopyString(pValue, (const char *)MapInfo->MapBRPrefix);
+            AnscCopyString(pValue, temp);
             return 0;
         }
         else
         {
-            *pUlSize = AnscSizeOfString((const char *)MapInfo->MapBRPrefix)+1;
+            *pUlSize = AnscSizeOfString(temp)+1;
             return 1;
         }
     }
 
     if (strcmp(ParamName, "MapRuleIPv4Prefix") == 0)
     {
-        if ( AnscSizeOfString((const char *)MapInfo->MapRuleIPv4Prefix) < *pUlSize)
+        (void)commonSyseventGet(SYSEVENT_MAP_RULE_IPADDRESS, temp, sizeof(temp));
+        if ( AnscSizeOfString(temp) < *pUlSize)
         {
-            AnscCopyString(pValue,(const char *) MapInfo->MapRuleIPv4Prefix);
+            AnscCopyString(pValue, temp);
             return 0;
         }
         else
         {
-            *pUlSize = AnscSizeOfString((const char *)MapInfo->MapRuleIPv4Prefix)+1;
+            *pUlSize = AnscSizeOfString(temp)+1;
             return 1;
         }
     }
 
     if (strcmp(ParamName, "MapRuleIPv6Prefix") == 0)
     {
-        if ( AnscSizeOfString((const char *)MapInfo->MapRuleIPv6Prefix) < *pUlSize)
+        (void)commonSyseventGet(SYSEVENT_MAP_RULE_IPV6_ADDRESS, temp, sizeof(temp));
+        if ( AnscSizeOfString(temp) < *pUlSize)
         {
-            AnscCopyString(pValue, (const char *)MapInfo->MapRuleIPv6Prefix);
+            AnscCopyString(pValue, temp);
             return 0;
         }
         else
         {
-            *pUlSize = AnscSizeOfString((const char *)MapInfo->MapRuleIPv6Prefix)+1;
+            *pUlSize = AnscSizeOfString(temp)+1;
             return 1;
         }
     }
 
     if (strcmp(ParamName, "MapIpv4Address") == 0)
     {
-        //TODO: This is a temporary solution, need to use the BBF MAP. DML from the WanManager
-        DHCPMGR_LOG_ERROR("%s %d MapIpv4Address not available in this context. returning from the device's sysvent db\n", __FUNCTION__, __LINE__);
-        char temp[256] = {0};
-        commonSyseventGet(SYSEVENT_MAPT_IPADDRESS, temp, sizeof(temp));
+        (void)commonSyseventGet(SYSEVENT_MAPT_IPADDRESS, temp, sizeof(temp));
         if ( AnscSizeOfString(temp) < *pUlSize)
         {
             AnscCopyString(pValue, temp);

--- a/source/TR-181/middle_layer_src/cosa_dhcpv6_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_dhcpv6_dml.c
@@ -76,6 +76,7 @@
 #include "cosa_apis_util.h"
 #include "util.h"
 
+#include <errno.h>
 #include <stdlib.h>
 #include <strings.h>
 #include <unistd.h>
@@ -3360,7 +3361,7 @@ dhcp6c_mapt_mape_GetParamUlongValue
         {
             errno = 0;
             *puLong = strtoul(temp, &endPtr, 10);
-            if (errno != 0 || endPtr == temp)
+            if (errno != 0 || endPtr == temp || *endPtr != '\0' || temp[0] == '-')
             {
                 DHCPMGR_LOG_ERROR("%s: invalid numeric value '%s' for %s", __FUNCTION__, temp, SYSEVENT_MAP_EA_LEN);
                 *puLong = 0;
@@ -3375,7 +3376,7 @@ dhcp6c_mapt_mape_GetParamUlongValue
         {
             errno = 0;
             *puLong = strtoul(temp, &endPtr, 10);
-            if (errno != 0 || endPtr == temp)
+            if (errno != 0 || endPtr == temp || *endPtr != '\0' || temp[0] == '-')
             {
                 DHCPMGR_LOG_ERROR("%s: invalid numeric value '%s' for %s", __FUNCTION__, temp, SYSEVENT_MAPT_PSID_OFFSET);
                 *puLong = 0;
@@ -3390,7 +3391,7 @@ dhcp6c_mapt_mape_GetParamUlongValue
         {
             errno = 0;
             *puLong = strtoul(temp, &endPtr, 10);
-            if (errno != 0 || endPtr == temp)
+            if (errno != 0 || endPtr == temp || *endPtr != '\0' || temp[0] == '-')
             {
                 DHCPMGR_LOG_ERROR("%s: invalid numeric value '%s' for %s", __FUNCTION__, temp, SYSEVENT_MAPT_PSID_LENGTH);
                 *puLong = 0;
@@ -3405,7 +3406,7 @@ dhcp6c_mapt_mape_GetParamUlongValue
         {
             errno = 0;
             *puLong = strtoul(temp, &endPtr, 10);
-            if (errno != 0 || endPtr == temp)
+            if (errno != 0 || endPtr == temp || *endPtr != '\0' || temp[0] == '-')
             {
                 DHCPMGR_LOG_ERROR("%s: invalid numeric value '%s' for %s", __FUNCTION__, temp, SYSEVENT_MAPT_PSID_VALUE);
                 *puLong = 0;
@@ -3420,7 +3421,7 @@ dhcp6c_mapt_mape_GetParamUlongValue
         {
             errno = 0;
             *puLong = strtoul(temp, &endPtr, 10);
-            if (errno != 0 || endPtr == temp)
+            if (errno != 0 || endPtr == temp || *endPtr != '\0' || temp[0] == '-')
             {
                 DHCPMGR_LOG_ERROR("%s: invalid numeric value '%s' for %s", __FUNCTION__, temp, SYSEVENT_MAPT_RATIO);
                 *puLong = 0;

--- a/source/TR-181/middle_layer_src/cosa_dhcpv6_dml.c
+++ b/source/TR-181/middle_layer_src/cosa_dhcpv6_dml.c
@@ -3563,7 +3563,6 @@ dhcp6c_mapt_mape_GetParamStringValue
             *pUlSize = AnscSizeOfString(temp)+1;
             return 1;
         }
-        return 0;
     }
 
     return -1;


### PR DESCRIPTION

Reason for change: Remove duplicated PSID derivation from DHCPManager MAP parsing, keep Ratio handling in place for the separate RDKB-65989 scope, and align legacy Device.DHCPv6.Client.{i}.X_RDKCENTRAL-COM_RcvOption.* reads with the sysevent values populated by WanManager.

Test Procedure: Verify Device.DHCPv6.Client.1.X_RDKCENTRAL-COM_RcvOption. returns proper values as set in sysevent. Compare with MAP events from "sysevent show /tmp/allevents && cat /tmp/allevents | grep -i map"
Risks: Low
Priority: P1
